### PR TITLE
Revert flexibility from the `ProductsResponse`.

### DIFF
--- a/bin/validateSchema.js
+++ b/bin/validateSchema.js
@@ -118,10 +118,6 @@ function getEventsApiJsonDataMockObjects() {
       path: './examples/get_event.json',
     },
     {
-      name: 'Events with extra fields',
-      path: './examples/get_event_extra_fields.json',
-    },
-    {
       name: '403 error',
       path: './examples/get_event_403_error.json',
     },
@@ -207,14 +203,14 @@ const {
 const visitorsApiJsonDataObjects = [...getVisitorsApiJsonDataMockObjects(), ...(await getVisitorsApiRealDataObjects())];
 const webhookDataObjects = getWebhookJsonDataMockObjects();
 
-const [realEventsData, eventsDataObjects, eventsWithExtraFields, event403Error, event404Error] = [
+const [realEventsData, eventsDataObjects, event403Error, event404Error] = [
   ...(await getEventApiRealDataObjects()),
   ...getEventsApiJsonDataMockObjects(),
 ];
 
 validateSchemaAgainstData(visitorsApiValidator, visitorsApiJsonDataObjects);
 validateSchemaAgainstData(webhookValidator, webhookDataObjects);
-validateSchemaAgainstData(eventsValidator, [eventsDataObjects, realEventsData, eventsWithExtraFields]);
+validateSchemaAgainstData(eventsValidator, [eventsDataObjects, realEventsData]);
 validateSchemaAgainstData(errorResponseEvent403Validator, [event403Error]);
 validateSchemaAgainstData(errorResponseEvent404Validator, [event404Error]);
 

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -528,7 +528,10 @@ components:
     ProductsResponse:
       type: object
       description: Contains all the information from each activated product - Fingerprint Pro or Bot Detection
-      additionalProperties: true
+      # The true default value for additionalProperties allows extending schema.
+      # However, explicit additionalProperties: true breaks swagger-codegen, therefore commented out.
+      # additionalProperties: true
+      additionalProperties: false
       properties:
         identification:
           type: object


### PR DESCRIPTION
SDK shouldn't fail with any new fields in the schema.