### PR TITLE
Feat/make schema pretty for readme explorer

### DIFF
--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -38,6 +38,50 @@ info:
   contact:
     name: Fingerprint Support
     email: support@fingerprint.com
+tags:
+  - name: Fingerprint
+    externalDocs:
+      description: | 
+        API documentation
+
+        ## Sure but what if this description was very long
+
+        I can use mardown here and **bold** text or *italic* text or `code` text
+
+        even lists:
+
+        - item 1
+        - item 2
+        - item 3
+
+        an tables
+
+        | Column 1 | Column 2 | Column 3 |
+        | -------- | -------- | -------- |
+        | Text     | Text     | Text     |
+        | Text     | Text     | Text     |
+
+        and subheadings
+
+        ## Subheading 1
+
+        ### Subheading 2
+
+        #### Subheading 3
+
+        some content
+
+        ##### Subheading 4
+
+        maybe code blocks
+
+        ```javascript
+        const a = 1;
+        const b = 2;
+        const c = a + b;
+        console.log(c);
+        ```
+      url: https://dev.fingerprint.com/docs/server-api
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -51,6 +95,8 @@ security:
 paths:
   /events/{request_id}:
     get:
+      tags:
+        - Fingerprint
       summary: Get event by requestId
       description: This endpoint allows you to get events with all the information from each activated product (Fingerprint Pro or Bot Detection). Use the requestId as a URL path :request_id parameter. This API method is scoped to a request, i.e. all returned information is by requestId.
       operationId: 'getEvent'
@@ -106,6 +152,8 @@ paths:
                   externalValue: '/examples/get_event_404_error.json'
   /visitors/{visitor_id}:
     get:
+      tags:
+        - Fingerprint
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: | 
@@ -264,6 +312,29 @@ paths:
                 example:
                   summary: Example too many requests error response
                   externalValue: '/examples/visits_too_many_requests_error.json'
+  /webhook:
+    trace:
+      tags:
+        - Fingerprint
+      description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
+      responses:
+        default:
+          description: Dummy for the schema
+      callbacks:
+        webhook:
+          webhook:
+            post:
+              description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/WebhookVisit'
+                    example:
+                      externalValue: '/examples/webhook.json'
+              responses:
+                default:
+                  description: The server doesn't validate the answer.
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Fingerprint Pro Server API
-  description: | 
+  description: |
     Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
 
@@ -41,7 +41,7 @@ info:
 tags:
   - name: Fingerprint
     externalDocs:
-      description: | 
+      description: |
         API documentation
 
         ## Sure but what if this description was very long
@@ -90,8 +90,8 @@ servers:
   - url: https://ap.api.fpjs.io
     description: Asia (Mumbai)
 security:
-  - ApiKeyHeader: [ ]
-  - ApiKeyQuery: [ ]
+  - ApiKeyHeader: []
+  - ApiKeyQuery: []
 paths:
   /events/{request_id}:
     get:
@@ -156,7 +156,7 @@ paths:
         - Fingerprint
       operationId: 'getVisits'
       summary: Get visits by visitorId
-      description: | 
+      description: |
         This endpoint allows you to get a history of visits with all available information. Use the `visitorId` as a URL path parameter. 
         This API method is scoped to a visitor, i.e. all returned information is by visitorId.
 
@@ -183,7 +183,7 @@ paths:
         #### Subheading 3
          
         some content
-        
+
         ##### Subheading 4
 
         maybe code blocks
@@ -235,7 +235,7 @@ paths:
             type: string
         #          example: 1654815516083.OX6kx8
         - name: linked_id
-          description: | 
+          description: |
             Filter visits by custom identifier
 
             If you need to associate events with your own identifier, use linkedId. 
@@ -245,7 +245,7 @@ paths:
             associated with your custom identifier.
 
             *bold* 
-            
+
             - dkeow
             - dkeow
           in: query
@@ -286,7 +286,7 @@ paths:
                   summary: Request with limit=500
                   externalValue: '/examples/visits_limit_500.json'
         '403':
-          description: "Forbidden. Probably ApiKey is missed or provided the wrong one."
+          description: 'Forbidden. Probably ApiKey is missed or provided the wrong one.'
           content:
             application/json:
               schema:
@@ -313,52 +313,35 @@ paths:
                   summary: Example too many requests error response
                   externalValue: '/examples/visits_too_many_requests_error.json'
   /webhook:
-    trace:
+    post:
       tags:
         - Fingerprint
-      description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
-      responses:
-        default:
-          description: Dummy for the schema
-      callbacks:
-        webhook:
-          webhook:
-            post:
-              description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
-              requestBody:
-                content:
-                  application/json:
-                    schema:
-                      $ref: '#/components/schemas/WebhookVisit'
-                    example:
-                      externalValue: '/examples/webhook.json'
-              responses:
-                default:
-                  description: The server doesn't validate the answer.
-webhooks:
-  # Each webhook needs a name
-  WebhookName:
-    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
-    post:
+      summary: Webhook from Fingerprint to your server
+      description: | 
+        You can configure webhooks to receive identification events as POST requests on your server. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
+        You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
       requestBody:
-        description: Information about a new pet in the system
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/WebhookVisit"
+              $ref: '#/components/schemas/WebhookVisit'
+            example:
+              externalValue: '/examples/webhook.json'
       responses:
-        "200":
-          description: Return a 200 status to indicate that the data was received successfully
+        200:
+          description: |
+            Return 200 OK to indicate that the data was received successfully. 
+            Every request is retried once if it timed out or returned a non-2XX response. The retry will take place 5 minutes after the non-2XX response is received or 5 minutes after the timeout takes place.
 components:
   securitySchemes:
     ApiKeyHeader:
       type: apiKey
-      in: header       # can be "header", "query" or "cookie"
-      name: Auth-API-Key  # name of the header, query parameter or cookie
+      in: header # can be "header", "query" or "cookie"
+      name: Auth-API-Key # name of the header, query parameter or cookie
     ApiKeyQuery:
       type: apiKey
-      in: query       # can be "header", "query" or "cookie"
-      name: api_key  # name of the header, query parameter or cookie
+      in: query # can be "header", "query" or "cookie"
+      name: api_key # name of the header, query parameter or cookie
   schemas:
     Response:
       type: object
@@ -373,7 +356,7 @@ components:
             allOf:
               - $ref: '#/components/schemas/Visit'
               - required:
-                - tag
+                  - tag
         lastTimestamp:
           description: When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), a special `lastTimestamp` top-level attribute is added to the response. If you want to paginate the results further in the past, you should use the value of this attribute.
           type: integer

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -133,7 +133,7 @@ paths:
               });
               const config = {
                 method: 'post',
-                url: 'https://api.example.com/v2/alert',
+                url: 'https://api.example.com/v2/:visitor_id',
                 headers: { 
                   'Content-Type': 'application/json'
                 },

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -345,7 +345,7 @@ webhooks:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Pet"
+              $ref: "#/components/schemas/WebhookVisit"
       responses:
         "200":
           description: Return a 200 status to indicate that the data was received successfully

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -39,6 +39,7 @@ paths:
     get:
       tags:
         - Events
+      operationId: 'getEvent'
       summary: Get event by `requestId`
       description: | 
         This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). 
@@ -46,7 +47,152 @@ paths:
         Use `requestId` as the URL path `:request_id` parameter.
 
         This API method is scoped to a request, i.e. all returned information is by `requestId`.
-      operationId: 'getEvent'
+      x-readme:
+        code-samples:
+          - language: node
+            name: Node SDK
+            install: npm install @fingerprintjs/fingerprintjs-pro-server-api
+            code: |
+              import {
+                FingerprintJsServerApiClient,
+                Region,
+              } from '@fingerprintjs/fingerprintjs-pro-server-api'
+
+              const client = new FingerprintJsServerApiClient({
+                apiKey: 'SERVER_API_KEY', // Replace with your key
+                region: Region.Global, // Replace with your region
+              })
+
+              // Get a specific fingerprinting event
+              client.getEvent('REQUEST_ID').then((event) => {
+                console.log(event)
+              })
+          - language: php
+            name: PHP SDK
+            install: composer require fingerprint/fingerprint-pro-server-api-sdk
+            code: |
+              <?php
+              require_once(__DIR__ . '/vendor/autoload.php');
+              use Fingerprint\ServerAPI\Api\FingerprintApi;
+              use Fingerprint\ServerAPI\Configuration;
+              use GuzzleHttp\Client;
+
+              $config = Configuration::getDefaultConfiguration(
+                "SERVER_API_KEY", // Replace with your key
+                Configuration::REGION_GLOBAL // Replace with your region
+              );
+
+              $client = new FingerprintApi(
+                new Client(),
+                $config
+              );
+
+              // Get a specific fingerprinting event
+              try {
+                $response = $client->getEvent("REQUEST_ID");
+                echo "<pre>" . $response->__toString() . "</pre>";
+              } catch (Exception $e) {
+                echo $e->getMessage(), PHP_EOL;
+              }
+          - language: python
+            name: Python SDK
+            install: pip install fingerprint_pro_server_api_sdk
+            code: |
+              import fingerprint_pro_server_api_sdk
+              from fingerprint_pro_server_api_sdk import EventResponse
+              from fingerprint_pro_server_api_sdk import Response
+              from fingerprint_pro_server_api_sdk.rest import ApiException
+
+              configuration = fingerprint_pro_server_api_sdk.Configuration(
+                api_key="SERVER_API_KEY", // Replace with your key
+                region="us" // Replace with your region
+              )
+              api_instance = fingerprint_pro_server_api_sdk.FingerprintApi(configuration)
+
+              # Get a specific fingerprinting event
+              try:
+                  event: EventResponse = api_instance.get_event("REQUEST_ID")
+                  print(event)
+              except ApiException as e:
+                  print("Exception when getting an event: %s\n" % e)
+          - language: golang
+            name: Go SDK
+            install: go get github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk
+            code: |
+              package main
+
+              import (
+                "context"
+                "fmt"
+                "github.com/antihax/optional"
+                "github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v3/sdk"
+                "log"
+              )
+
+              func main() {
+                cfg := sdk.NewConfiguration()
+                client := sdk.NewAPIClient(cfg)
+
+                auth := context.WithValue(
+                  context.Background(),
+                  sdk.ContextAPIKey,
+                  sdk.APIKey{Key: "SERVER_API_KEY"}, // Replace with your key
+                )
+                cfg.ChangeRegion(sdk.RegionUS) // Replace with your region
+
+                // Get a specific fingerprinting event
+                event, eventHttpRes, eventErr :=
+                  client.FingerprintApi.GetEvent(auth, "REQUEST_ID")
+                if eventErr != nil {
+                  log.Fatal(eventErr)
+                }
+                fmt.Printf("Event: %s", event)
+              }
+          - language: java
+            name: Java SDK
+            code: | 
+              import com.fingerprint.api.FingerprintApi;
+              import com.fingerprint.models.EventResponse;
+              import com.fingerprint.models.Response;
+              import com.fingerprint.sdk.ApiClient;
+              import com.fingerprint.sdk.ApiException;
+              import com.fingerprint.sdk.Configuration;
+              import com.fingerprint.sdk.Region;
+
+              public class FingerprintApiExample {
+                public static void main(String... args) {
+                  ApiClient client = Configuration.getDefaultApiClient(
+                    "SERVER_API_KEY", // Replace with your key
+                    Region.GLOBAL // Replace with your region
+                  );
+                  FingerprintApi api = new FingerprintApi(client);
+
+                  // Get a specific fingerprinting event
+                  try {
+                    EventResponse response = api.getEvent("REQUEST_ID");
+                    System.out.println(response.getProducts().toString());
+                  } catch (ApiException e) {
+                    System.err.println(e.getMessage());
+                  }
+                }
+              }
+          - language: csharp
+            name: C# SDK
+            install: dotnet add package FingerprintPro.ServerSdk
+            code: |
+              using FingerprintPro.ServerSdk.Api;
+              using FingerprintPro.ServerSdk.Client;
+
+              var configuration = new Configuration("SERVER_API_KEY"); // Replace with your key
+              configuration.Region = Region.Us; // Replace with your region
+
+              var api = new FingerprintApi(
+                  configuration
+              );
+
+              // Get a specific fingerprinting event
+              var events = api.GetEvent("REQUEST_ID");
+              Console.WriteLine(events);
       parameters:
         - name: request_id
           in: path

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -46,6 +46,59 @@ paths:
         Products that are not activated for your application or not relevant to the event's detected platform (web, iOS, Android) are not included in the response. 
         
         Use `requestId` as the URL path parameter. This API method is scoped to a request, i.e. all returned information is by `requestId`.
+      parameters:
+        - name: request_id
+          in: path
+          description: The unique [identifier](https://dev.fingerprint.com/docs/js-agent#requestid) of each analysis request.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventResponse'
+              examples:
+                fullResponse:
+                  summary: Example response
+                  externalValue: '/examples/get_event.json'
+                allErrorsResponse:
+                  summary: All failed signals
+                  externalValue: '/examples/get_event_all_errors.json'
+                withBotdError:
+                  summary: BotD error
+                  externalValue: '/examples/get_event_botd_failed_error.json'
+                withBotdTooManyRequestsError:
+                  summary: BotD too many requests error
+                  externalValue: '/examples/get_event_botd_too_many_requests_error.json'
+                withIdentificationError:
+                  summary: Identification error
+                  externalValue: '/examples/get_event_identification_failed_error.json'
+                withIdentificationTooManyRequestsError:
+                  summary: Identification too many requests error
+                  externalValue: '/examples/get_event_identification_too_many_requests_error.json'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEvent403Response'
+              examples:
+                example:
+                  summary: Example response
+                  externalValue: '/examples/get_event_403_error.json'
+        '404':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEvent404Response'
+              examples:
+                example:
+                  summary: Example response
+                  externalValue: '/examples/get_event_404_error.json'
       x-readme:
         code-samples:
           - language: node
@@ -192,59 +245,6 @@ paths:
               // Get a specific fingerprinting event
               var events = api.GetEvent("REQUEST_ID");
               Console.WriteLine(events);
-      parameters:
-        - name: request_id
-          in: path
-          description: The unique [identifier](https://dev.fingerprint.com/docs/js-agent#requestid) of each analysis request.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EventResponse'
-              examples:
-                fullResponse:
-                  summary: Example response
-                  externalValue: '/examples/get_event.json'
-                allErrorsResponse:
-                  summary: All failed signals
-                  externalValue: '/examples/get_event_all_errors.json'
-                withBotdError:
-                  summary: BotD error
-                  externalValue: '/examples/get_event_botd_failed_error.json'
-                withBotdTooManyRequestsError:
-                  summary: BotD too many requests error
-                  externalValue: '/examples/get_event_botd_too_many_requests_error.json'
-                withIdentificationError:
-                  summary: Identification error
-                  externalValue: '/examples/get_event_identification_failed_error.json'
-                withIdentificationTooManyRequestsError:
-                  summary: Identification too many requests error
-                  externalValue: '/examples/get_event_identification_too_many_requests_error.json'
-        '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEvent403Response'
-              examples:
-                example:
-                  summary: Example response
-                  externalValue: '/examples/get_event_403_error.json'
-        '404':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEvent404Response'
-              examples:
-                example:
-                  summary: Example response
-                  externalValue: '/examples/get_event_404_error.json'
   /visitors/{visitor_id}:
     get:
       tags:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -156,27 +156,6 @@ paths:
                 example:
                   summary: Example too many requests error response
                   externalValue: '/examples/visits_too_many_requests_error.json'
-  /webhook:
-    trace:
-      description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
-      responses:
-        default:
-          description: Dummy for the schema
-      callbacks:
-        webhook:
-          webhook:
-            post:
-              description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
-              requestBody:
-                content:
-                  application/json:
-                    schema:
-                      $ref: '#/components/schemas/WebhookVisit'
-                    example:
-                      externalValue: '/examples/webhook.json'
-              responses:
-                default:
-                  description: The server doesn't validate the answer.
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -40,13 +40,12 @@ paths:
       tags:
         - Events
       operationId: 'getEvent'
-      summary: Get event by `requestId`
+      summary: Get event by requestId
       description: | 
-        This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). 
+        This endpoint allows you to retrieve an individual analysis event with all the information from each activated product (Identification, Bot Detection, and others).
+        Products that are not activated for your application or not relevant to the event's detected platform (web, iOS, Android) are not included in the response. 
         
-        Use `requestId` as the URL path `:request_id` parameter.
-
-        This API method is scoped to a request, i.e. all returned information is by `requestId`.
+        Use `requestId` as the URL path parameter. This API method is scoped to a request, i.e. all returned information is by `requestId`.
       x-readme:
         code-samples:
           - language: node
@@ -196,7 +195,7 @@ paths:
       parameters:
         - name: request_id
           in: path
-          description: The unique identifier of each analysis request
+          description: The unique [identifier](https://dev.fingerprint.com/docs/js-agent#requestid) of each analysis request.
           required: true
           schema:
             type: string
@@ -258,10 +257,7 @@ paths:
 
         #### Headers
 
-        `Retry-After`
-
-        Indicates how long you should wait before making a follow-up request.
-        The value is non-negative decimal integer indicating the seconds to delay after the response is received.
+        * `Retry-After`: Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
       x-readme:
         code-samples:
           - language: node
@@ -413,7 +409,7 @@ paths:
               Console.WriteLine(visits);
       parameters:
         - name: visitor_id
-          description: Unique identifier of the visitor.
+          description: Unique identifier of the visitor issued by Fingerprint Pro.
           in: path
           required: true
           schema:
@@ -423,7 +419,7 @@ paths:
           description: | 
             Filter visits by `requestId`. 
             
-            Every identification request has a unique identifier associated with it called `requestId`. This identifier is returned to the client in the API call response. When you filter visits by `requestId`, only one visit will be returned.
+            Every identification request has a unique identifier associated with it called `requestId`. This identifier is returned to the client in the identification [result](https://dev.fingerprint.com/docs/js-agent#requestid). When you filter visits by `requestId`, only one visit will be returned.
           in: query
           schema:
             type: string
@@ -432,7 +428,7 @@ paths:
           description: |
             Filter visits by your custom identifier. 
             
-            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example: session ID, purchase ID, or transaction ID. You can then use this `linked_id` parameter to retrieve all visits associated with your custom identifier.
+            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example: session ID, purchase ID, or transaction ID. You can then use this `linked_id` parameter to retrieve all events associated with your custom identifier.
           in: query
           schema:
             type: string
@@ -458,14 +454,11 @@ paths:
             When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
             You can use this attribute to get the next page of results — the visits that happened before that timestamp.
 
-            ```
-            // 1st request, returning most recent 200 events:
-            GET api-base-url/visitors/:visitorId?limit=200
-            // Use response.lastTimestamp to get the next page of results
-            GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567
-            ```
+            1. First request, returning most recent 200 events: `GET api-base-url/visitors/:visitorId?limit=200`
+            2. Use response.lastTimestamp to get the next page of results: `GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567`
 
-            Pagination happens during scanning and before filtering, so you can get less visits that the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
+
+            Pagination happens during scanning and before filtering, so you can get less visits than the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
           in: query
           schema:
             type: integer
@@ -501,7 +494,7 @@ paths:
           description: Too Many Requests
           headers:
             Retry-After:
-              description: Indicates how long the user should wait before attempting the next request.
+              description: Indicates how long you should wait before attempting the next request.
               schema:
                 type: integer
                 format: int32

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -76,7 +76,47 @@ paths:
     get:
       operationId: 'getVisits'
       summary: Get visits by visitorId
-      description: This endpoint allows you to get a history of visits with all available information. Use the visitorId as a URL path parameter. This API method is scoped to a visitor, i.e. all returned information is by visitorId.
+      description: | 
+        This endpoint allows you to get a history of visits with all available information. Use the `visitorId` as a URL path parameter. 
+        This API method is scoped to a visitor, i.e. all returned information is by visitorId.
+
+        I can use mardown here and **bold** text or *italic* text or `code` text 
+        even lists:
+        - item 1
+        - item 2
+        - item 3
+
+        an tables 
+
+        | Column 1 | Column 2 | Column 3 |
+        | -------- | -------- | -------- |
+        | Text     | Text     | Text     |
+        | Text     | Text     | Text     |
+        | Text     | Text     | Text     |
+
+        and subheadings
+
+        ## Subheading 1
+
+        ### Subheading 2
+
+        #### Subheading 3
+         
+        some content
+        
+        ##### Subheading 4
+
+        maybe code blocks
+
+        ```javascript
+        const a = 1;
+        const b = 2;
+        const c = a + b;
+        console.log(c);
+        ```
+
+        or links to documentation [Fingerprint Pro](https://fingerprintjs.com/)
+
       parameters:
         - name: visitor_id
           in: path

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -34,11 +34,11 @@ paths:
         - Events
       summary: Get event by `requestId`
       description: | 
-        # `GET` **/events/:requestId**
-        This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). Use `requestId` as the URL path `:request_id` parameter. 
-        This API method is scoped to a request, i.e. all returned information is by `requestId`.
-
+        This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). 
         
+        Use `requestId` as the URL path `:request_id` parameter.
+
+        This API method is scoped to a request, i.e. all returned information is by `requestId`.
       operationId: 'getEvent'
       parameters:
         - name: request_id
@@ -59,16 +59,16 @@ paths:
                   summary: Example response
                   externalValue: '/examples/get_event.json'
                 withBotdError:
-                  summary: Example error response with BotD error
+                  summary:  BotD error
                   externalValue: '/examples/get_event_botd_failed_error.json'
                 withBotdTooManyRequestsError:
-                  summary: Example error response with BotD error when too many requests are sent
+                  summary:  BotD too many requests error
                   externalValue: '/examples/get_event_botd_too_many_requests_error.json'
                 withIdentificationError:
-                  summary: Example error response with identification error
+                  summary: Identification error
                   externalValue: '/examples/get_event_identification_failed_error.json'
                 withIdentificationTooManyRequestsError:
-                  summary: Example error response with identification error when too many requests are sent
+                  summary: Identification too many requests error
                   externalValue: '/examples/get_event_identification_too_many_requests_error.json'
         '403':
           description: Forbidden

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -125,8 +125,8 @@ paths:
               } from '@fingerprintjs/fingerprintjs-pro-server-api'
 
               const client = new FingerprintJsServerApiClient({
-                apiKey: SERVER_API_KEY,
-                region: APP_REGION,
+                apiKey: 'SERVER_API_KEY', // Replace with your key
+                region: Region.Global, // Replace with your region
               })
 
               // Get visit history of a specific visitor
@@ -144,8 +144,8 @@ paths:
               use GuzzleHttp\Client;
 
               $config = Configuration::getDefaultConfiguration(
-                SERVER_API_KEY,
-                REGION
+                "SERVER_API_KEY", // Replace with your key
+                Configuration::REGION_GLOBAL // Replace with your region
               );
 
               $client = new FingerprintApi(
@@ -155,7 +155,7 @@ paths:
 
               // Get visit history of a specific visitor
               try {
-                $response = $client->getVisits("<visitorId>");
+                $response = $client->getVisits("VISITOR_ID");
                 echo "<pre>" . $response->__toString() . "</pre>";
               } catch (Exception $e) {
                 echo $e->getMessage(), PHP_EOL;
@@ -170,14 +170,14 @@ paths:
               from fingerprint_pro_server_api_sdk.rest import ApiException
 
               configuration = fingerprint_pro_server_api_sdk.Configuration(
-                api_key=SERVER_API_KEY,
-                region=REGION
+                api_key="SERVER_API_KEY", // Replace with your key
+                region="us" // Replace with your region
               )
               api_instance = fingerprint_pro_server_api_sdk.FingerprintApi(configuration)
 
               # Get visit history of a specific visitor
               try:
-                visits: Response = api_instance.get_visits("<visitorId>", limit=10)
+                visits: Response = api_instance.get_visits("VISITOR_ID", limit=10)
                 print(visits)
               except ApiException as e:
                 print("Exception when getting visits: %s\n" % e)
@@ -202,16 +202,16 @@ paths:
                 auth := context.WithValue(
                   context.Background(),
                   sdk.ContextAPIKey,
-                  sdk.APIKey{Key: <SERVER_API_KEY>},
+                  sdk.APIKey{Key: "SERVER_API_KEY"}, // Replace with your key
                 )
-                cfg.ChangeRegion(<REGION>)
+                cfg.ChangeRegion(sdk.RegionUS) // Replace with your region
 
                 // Get visit history of a specific visitor
                 getVisitsOpts := sdk.FingerprintApiGetVisitsOpts{
                   Limit: optional.NewInt32(10),
                 }
                 history, historyHttpRes, historyErr :=
-                  client.FingerprintApi.GetVisits(auth, "<visitorId", &getVisitsOpts)
+                  client.FingerprintApi.GetVisits(auth, "VISITOR_ID", &getVisitsOpts)
                 if err != nil {
                   log.Fatal(err)
                 }
@@ -231,14 +231,14 @@ paths:
               public class FingerprintApiExample {
                 public static void main(String... args) {
                   ApiClient client = Configuration.getDefaultApiClient(
-                    <SERVER_API_KEY>,
-                    <REGION>
+                    "SERVER_API_KEY", // Replace with your key
+                    Region.GLOBAL // Replace with your region
                   );
                   FingerprintApi api = new FingerprintApi(client);
 
                   // Get visit history of a specific visitor
                   try {
-                    Response response = api.getVisits("<visitorID>");
+                    Response response = api.getVisits("VISITOR_ID");
                     System.out.println(response.getVisits().toString());
                   } catch (ApiException e) {
                     System.err.println(e.getMessage());
@@ -252,15 +252,15 @@ paths:
               using FingerprintPro.ServerSdk.Api;
               using FingerprintPro.ServerSdk.Client;
 
-              var configuration = new Configuration(<SERVER_API_KEY>);
-              configuration.Region = <REGION>;
+              var configuration = new Configuration("SERVER_API_KEY"); // Replace with your key
+              configuration.Region = Region.Us; // Replace with your region
 
               var api = new FingerprintApi(
                   configuration
               );
 
               // Get visit history of a specific visitor
-              var visits = api.GetVisits("<visitorId>");
+              var visits = api.GetVisits("VISITOR_ID");
               Console.WriteLine(visits);
       parameters:
         - name: visitor_id

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -6,11 +6,6 @@ info:
   contact:
     name: Fingerprint Support
     email: support@fingerprint.com
-tags:
-  - name: Fingerprint
-    externalDocs:
-      description: API documentation
-      url: https://dev.fingerprint.com/docs/server-api
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -24,8 +19,6 @@ security:
 paths:
   /events/{request_id}:
     get:
-      tags:
-        - Fingerprint
       summary: Get event by requestId
       description: This endpoint allows you to get events with all the information from each activated product (Fingerprint Pro or Bot Detection). Use the requestId as a URL path :request_id parameter. This API method is scoped to a request, i.e. all returned information is by requestId.
       operationId: 'getEvent'
@@ -81,8 +74,6 @@ paths:
                   externalValue: '/examples/get_event_404_error.json'
   /visitors/{visitor_id}:
     get:
-      tags:
-        - Fingerprint
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: This endpoint allows you to get a history of visits with all available information. Use the visitorId as a URL path parameter. This API method is scoped to a visitor, i.e. all returned information is by visitorId.
@@ -167,8 +158,6 @@ paths:
                   externalValue: '/examples/visits_too_many_requests_error.json'
   /webhook:
     trace:
-      tags:
-        - Fingerprint
       description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
       responses:
         default:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -257,7 +257,7 @@ paths:
 
         #### Headers
 
-        * `Retry-After`: Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
+        * `Retry-After` — Present in case of `429 Too many requests`. Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
       parameters:
         - name: visitor_id
           description: Unique identifier of the visitor issued by Fingerprint Pro.

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -1080,7 +1080,7 @@ components:
             error:
               $ref: '#/components/schemas/ProductError'
     EventResponse:
-      description: Contains event from all activated products - Fingerprint Pro, Bot Detection, and others.
+      description: Contains results from all activated products - Fingerprint Pro, Bot Detection, and others.
       type: object
       additionalProperties: false
       properties:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -337,7 +337,7 @@ paths:
                   description: The server doesn't validate the answer.
 webhooks:
   # Each webhook needs a name
-  newPet:
+  WebhookName:
     # This is a Path Item Object, the only difference is that the request is initiated by the API provider
     post:
       requestBody:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -8,15 +8,13 @@ info:
   contact:
     name: Fingerprint Support
     email: support@fingerprint.com
-tags:
-  - name: Events
-    # externalDocs:
-    #   url: https://dev.fingerprint.com/docs/server-api
-    description: |
-      Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
-  - name: Visitors
-    description: |
-      Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
+# tags:
+#   - name: Events
+#     description: |
+#       Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
+#   - name: Visitors
+#     description: |
+#       Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -30,8 +28,8 @@ security:
 paths:
   /events/{request_id}:
     get:
-      tags:
-        - Events
+      # tags:
+      #   - Events
       summary: Get event by `requestId`
       description: | 
         This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). 
@@ -92,8 +90,8 @@ paths:
                   externalValue: '/examples/get_event_404_error.json'
   /visitors/{visitor_id}:
     get:
-      tags:
-        - Visitors
+      # tags:
+      #   - Visitors
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -111,7 +111,7 @@ paths:
 
         `Retry-After`
 
-        Indicates how long the user should wait before making a follow-up request.
+        Indicates how long you should wait before making a follow-up request.
         The value is non-negative decimal integer indicating the seconds to delay after the response is received.
       x-readme:
         code-samples:
@@ -272,16 +272,18 @@ paths:
           example: uYIm7Ksp5rf00SllPhFp
         - name: request_id
           description: | 
-            Every identification event has a unique identifier, associated with it, called `requestId`. This identifier is returned back into the browser during the identification API call and is also available in API responses.  
-            It is a convenient way to return the exact identification event that you need. When you filter events with `requestId`, only one event will be returned, because every event has a unique `requestId`.
+            Filter visits by `requestId`. 
+            
+            Every identification request has a unique identifier, associated with it, called `requestId`. This identifier is returned to the client in the API call response. When you filter visits by `requestId`, only one visit will be returned.
           in: query
           schema:
             type: string
             # example: 1654815516083.OX6kx8
         - name: linked_id
           description: |
-            If you need to associate events with your own identifier, use `linkedId`. You can use it in different scenarios: e.g., identify by sessionID, identify by purchaseID or by your custom transaction number.
-            You should use `requestId` to get a single event, whereas you should use `linkedId` to retrieve several events, associated with your custom identifier.
+            Filter visits by your custom identifier. 
+            
+            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example, session ID, purchase ID or transaction ID. You can then use this `linked_id` parameter to retrieve all visits associated with your custom identifier.
           in: query
           schema:
             type: string
@@ -289,18 +291,10 @@ paths:
            # example: some_id
         - name: limit
           description: | 
-            For performance reasons, visitors API first performs events scanning and then filtering. Filtering always happens after the results are scanned.  
-            `Limit` is a parameter to specify how many events should be scanned. Results are always returned sorted by the timestamp in descending order \(most recent first\), so scanning the results limits how many events are scanned back in the past.  
-            By default, the visits API scans 100 events. However you can specify a different `limit` parameter, to scan fewer or more results. A maximum value of 500 results can be scanned and returned.
-            After the results were scanned, the filtering is applied to them, e.g., filtering by `requestId` or by `linkedId`.
-
-            **Using limit example**: your website visitor was identified 120 times and 120 events are stored in our database. Last 10 events are associated with a sessionID = 1234ADF; You want to scan last 50 events and filter them by your sessionID = 1234ADF. You can achieve this by using this query:  
-
-            ```
-            GET api-base-url/visitors/:visitorId?limit=50&linked_id=1234ADF
-            ```
-
-            Only 10 rows from the most recent 50 will be returned.
+            Limit scanned results. 
+            
+            For performance reasons, the API first scans some number of events before filtering them. Use `limit` to specify how many events are scanned before they are filtered by `requestId` or `linkedId`. Results are always returned sorted by the timestamp (most recent first).
+            By default, the most recent 100 visits are scanned, the maximum is 500. 
           in: query
           schema:
             type: integer
@@ -310,23 +304,19 @@ paths:
             # example: 10
         - name: before
           description: | 
-            Timestamp (in milliseconds since epoch) used to paginate results.
+            Timestamp (in milliseconds since epoch) used to paginate results. 
 
-            When more results are available \(e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available\), a special `lastTimestamp` top-level attribute is added to the response. You should use the value of this attribute, if you want to paginate the results further in the past, to return the events that happened before that timestamp.
-
-            Example of using `before` parameter:
+            When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
+            You can use the value of this attribute to get the next page of results further in the past, to return the visits that happened before that timestamp.
 
             ```
             // 1st request, returning most recent 200 events:
             GET api-base-url/visitors/:visitorId?limit=200
-            // Note that the response has lastTimestamp attribute in the response.
-            // Use that attribute to return the events that happened before, i.e
-            // next page of 200 events
+            // Use response.lastTimestamp to get the next page of results
             GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567
             ```
 
-            Note that pagination happens during scanning of the results, so if you used pagination + filtering, 
-            you can have just a few results back, with potentially more results available for pagination. These timestamps are stored with a millisecond precision. 
+            Pagination happens during scanning and before filtering, so you can get less visits that the `limit` you specified with more available on the next page. 
             When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
           in: query
           schema:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -1,7 +1,39 @@
 openapi: 3.0.3
 info:
   title: Fingerprint Pro Server API
-  description: Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. This API can be used for data exports, decision-making, and data analysis scenarios.
+  description: | 
+    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
+    Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
+
+    ## Regions
+
+    The server API is available in the **Global**, **EU** and **Asia (Mumbai)** regions. Each region is available on it's own domain:
+
+    | Region        | Base URL                 | Server Location     |
+    | :------------ | :----------------------- | :------------------ |
+    | Global        | `https://api.fpjs.io`    | Global              |
+    | EU            | `https://eu.api.fpjs.io` | Frankfurt,  Germany |
+    | Asia (Mumbai) | `https://ap.api.fpjs.io` | Mumbai,  India      |
+
+    ## Authentication
+
+    There are 2 ways to authenticate with the API: with auth header or with a query parameter. All unauthenticated requests will return HTTP 403 \(forbidden\) response.
+
+    ### Auth header
+
+    This is the recommended way of API authentication. When making an API request, add `Auth-API-Key` HTTP header with your [secret API key](doc:quick-start-guide#server-api).
+
+    ### API key query parameter
+
+    This method of authentication is easy to use when you want to test it in the browser. However we don't recommend using it in production.
+
+    Example request with an API key query parameter:
+
+    ```http
+    // Paste this URL into your browser
+    // replace the API key with your real secret API key
+    https://api.fpjs.io/visitors/someVisitorId?api_key=<<apiKey>>
+    ```
   version: '3'
   contact:
     name: Fingerprint Support

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -4,36 +4,6 @@ info:
   description: |
     Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
-
-    ## Regions
-
-    The server API is available in the **Global**, **EU** and **Asia (Mumbai)** regions. Each region is available on it's own domain:
-
-    | Region        | Base URL                 | Server Location     |
-    | :------------ | :----------------------- | :------------------ |
-    | Global        | `https://api.fpjs.io`    | Global              |
-    | EU            | `https://eu.api.fpjs.io` | Frankfurt,  Germany |
-    | Asia (Mumbai) | `https://ap.api.fpjs.io` | Mumbai,  India      |
-
-    ## Authentication
-
-    There are 2 ways to authenticate with the API: with auth header or with a query parameter. All unauthenticated requests will return HTTP 403 \(forbidden\) response.
-
-    ### Auth header
-
-    This is the recommended way of API authentication. When making an API request, add `Auth-API-Key` HTTP header with your [secret API key](doc:quick-start-guide#server-api).
-
-    ### API key query parameter
-
-    This method of authentication is easy to use when you want to test it in the browser. However we don't recommend using it in production.
-
-    Example request with an API key query parameter:
-
-    ```http
-    // Paste this URL into your browser
-    // replace the API key with your real secret API key
-    https://api.fpjs.io/visitors/someVisitorId?api_key=<<apiKey>>
-    ```
   version: '3'
   contact:
     name: Fingerprint Support
@@ -41,47 +11,48 @@ info:
 tags:
   - name: Fingerprint
     externalDocs:
-      description: |
-        API documentation
-
-        ## Sure but what if this description was very long
-
-        I can use mardown here and **bold** text or *italic* text or `code` text
-
-        even lists:
-
-        - item 1
-        - item 2
-        - item 3
-
-        an tables
-
-        | Column 1 | Column 2 | Column 3 |
-        | -------- | -------- | -------- |
-        | Text     | Text     | Text     |
-        | Text     | Text     | Text     |
-
-        and subheadings
-
-        ## Subheading 1
-
-        ### Subheading 2
-
-        #### Subheading 3
-
-        some content
-
-        ##### Subheading 4
-
-        maybe code blocks
-
-        ```javascript
-        const a = 1;
-        const b = 2;
-        const c = a + b;
-        console.log(c);
-        ```
       url: https://dev.fingerprint.com/docs/server-api
+    description: |
+      API documentation
+
+      ## Sure but what if this description was very long
+
+      I can use mardown here and **bold** text or *italic* text or `code` text
+
+      even lists:
+
+      - item 1
+      - item 2
+      - item 3
+
+      an tables
+
+      | Column 1 | Column 2 | Column 3 |
+      | -------- | -------- | -------- |
+      | Text     | Text     | Text     |
+      | Text     | Text     | Text     |
+
+      and subheadings
+
+      ## Subheading 1
+
+      ### Subheading 2
+
+      #### Subheading 3
+
+      some content
+
+      ##### Subheading 4
+
+      maybe code blocks
+
+      ```javascript
+      const a = 1;
+      const b = 2;
+      const c = a + b;
+      console.log(c);
+      ```
+
 servers:
   - url: https://api.fpjs.io
     description: Global

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -25,18 +25,15 @@ servers:
 security:
   - ApiKeyHeader: []
   - ApiKeyQuery: []
-x-readme: {
-  # explorer-enabled: false,
-  # proxy-enabled: false,
+x-readme: 
   samples-languages: 
-  - "curl"
-  - "node"
-  - "php"
-  - "python"
-  - "golang"
-  - "java"
-  - "csharp"
-}
+  - curl
+  - node
+  - php
+  - python
+  - golang
+  - java
+  - csharp
 paths:
   /events/{request_id}:
     get:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -131,7 +131,19 @@ paths:
             type: string
         #          example: 1654815516083.OX6kx8
         - name: linked_id
-          description: Filter visits by custom identifier
+          description: | 
+            Filter visits by custom identifier
+
+            If you need to associate events with your own identifier, use linkedId. 
+            You can use it in different scenarios: e.g., identify by sessionID, 
+            identify by purchaseID or by your custom transaction number. 
+            You should use requestId to get a single event, whereas you should use linkedId to retrieve several events,
+            associated with your custom identifier.
+
+            *bold* 
+            
+            - dkeow
+            - dkeow
           in: query
           schema:
             type: string

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -497,7 +497,7 @@ components:
           description: Unique identifier of the user's identification request.
           type: string
           example: '1654815516083.OX6kx8'
-        browser Details:
+        browserDetails:
           $ref: '#/components/schemas/BrowserDetails'
         incognito:
           description: Flag if user used incognito session.

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -196,7 +196,7 @@ paths:
       parameters:
         - name: request_id
           in: path
-          description: The unique identifier of each fingerprinting event
+          description: The unique identifier of each analysis request
           required: true
           schema:
             type: string
@@ -511,6 +511,29 @@ paths:
                 example:
                   summary: Example too many requests error response
                   externalValue: '/examples/visits_too_many_requests_error.json'
+  /webhook:
+    trace:
+      tags:
+        - Fingerprint
+      description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
+      responses:
+        default:
+          description: Dummy for the schema
+      callbacks:
+        webhook:
+          webhook:
+            post:
+              description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/WebhookVisit'
+                    example:
+                      externalValue: '/examples/webhook.json'
+              responses:
+                default:
+                  description: The server doesn't validate the answer.
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -212,13 +212,13 @@ paths:
                   summary: Example response
                   externalValue: '/examples/get_event.json'
                 allErrorsResponse:
-                  summary: Example response with all failed signals
+                  summary: All failed signals
                   externalValue: '/examples/get_event_all_errors.json'
                 withBotdError:
-                  summary:  BotD error
+                  summary: BotD error
                   externalValue: '/examples/get_event_botd_failed_error.json'
                 withBotdTooManyRequestsError:
-                  summary:  BotD too many requests error
+                  summary: BotD too many requests error
                   externalValue: '/examples/get_event_botd_too_many_requests_error.json'
                 withIdentificationError:
                   summary: Identification error
@@ -488,7 +488,7 @@ paths:
                   summary: Request with limit=500
                   externalValue: '/examples/visits_limit_500.json'
         '403':
-          description: 'Forbidden. Probably ApiKey is missed or provided the wrong one.'
+          description: Forbidden. The API Key is probably missing or incorrect.
           content:
             application/json:
               schema:
@@ -561,7 +561,7 @@ components:
             allOf:
               - $ref: '#/components/schemas/Visit'
               - required:
-                  - tag
+                - tag
         lastTimestamp:
           description: When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), a special `lastTimestamp` top-level attribute is added to the response. If you want to paginate the results further in the past, you should use the value of this attribute.
           type: integer
@@ -1087,7 +1087,7 @@ components:
             error:
               $ref: '#/components/schemas/ProductError'
     EventResponse:
-      description: Contains event from all activated products - Fingerprint Pro, Bot Detection, AEV
+      description: Contains event from all activated products - Fingerprint Pro, Bot Detection, and others.
       type: object
       additionalProperties: false
       properties:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -9,12 +9,12 @@ info:
     name: Fingerprint Support
     email: support@fingerprint.com
 tags:
-  - name: Fingerprint
+  - name: Events
     description: |
-      Using the Server API you can retrieve information about individual analysis events or event history of individual visitors.
-    externalDocs:
-      description: API documentation
-      url: https://dev.fingerprint.com/reference/pro-server-api
+      Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
+  - name: Visitors
+    description: |
+      Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -38,7 +38,7 @@ paths:
   /events/{request_id}:
     get:
       tags:
-        - Fingerprint
+        - Events
       operationId: 'getEvent'
       summary: Get event by requestId
       description: | 
@@ -248,7 +248,7 @@ paths:
   /visitors/{visitor_id}:
     get:
       tags:
-        - Fingerprint
+        - Visitors
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -8,13 +8,13 @@ info:
   contact:
     name: Fingerprint Support
     email: support@fingerprint.com
-# tags:
-#   - name: Events
-#     description: |
-#       Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
-#   - name: Visitors
-#     description: |
-#       Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
+tags:
+  - name: Events
+    description: |
+      Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
+  - name: Visitors
+    description: |
+      Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -28,8 +28,8 @@ security:
 paths:
   /events/{request_id}:
     get:
-      # tags:
-      #   - Events
+      tags:
+        - Events
       summary: Get event by `requestId`
       description: | 
         This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). 
@@ -90,8 +90,8 @@ paths:
                   externalValue: '/examples/get_event_404_error.json'
   /visitors/{visitor_id}:
     get:
-      # tags:
-      #   - Visitors
+      tags:
+        - Visitors
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -25,6 +25,11 @@ servers:
 security:
   - ApiKeyHeader: []
   - ApiKeyQuery: []
+x-readme: {
+  # explorer-enabled: false,
+  # proxy-enabled: false,
+  samples-languages: ["curl", "node", "php", "python", "golang", "java", "csharp"]
+}
 paths:
   /events/{request_id}:
     get:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -31,9 +31,9 @@ x-readme:
   - node
   - php
   - python
-  - golang
-  - java
   - csharp
+  - java
+  - go
 paths:
   /events/{request_id}:
     get:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -28,7 +28,14 @@ security:
 x-readme: {
   # explorer-enabled: false,
   # proxy-enabled: false,
-  samples-languages: ["curl", "node", "php", "python", "golang", "java", "csharp"]
+  samples-languages: 
+  - "curl"
+  - "node"
+  - "php"
+  - "python"
+  - "golang"
+  - "java"
+  - "csharp"
 }
 paths:
   /events/{request_id}:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -37,6 +37,8 @@ paths:
         # `GET` **/events/:requestId**
         This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). Use `requestId` as the URL path `:request_id` parameter. 
         This API method is scoped to a request, i.e. all returned information is by `requestId`.
+
+        
       operationId: 'getEvent'
       parameters:
         - name: request_id

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -335,6 +335,20 @@ paths:
               responses:
                 default:
                   description: The server doesn't validate the answer.
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -298,18 +298,23 @@ paths:
             minimum: 0
             # default: 0
             # example: 10
-        - name: before
-          description: | 
-            Timestamp (in milliseconds since epoch) used to paginate results. 
-
-            When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
-            You can use this attribute to get the next page of results — the visits that happened before that timestamp.
+        - name: paginationKey
+          description: |
+            Use `paginationKey` to get the next page of results. 
+            
+            When more results are available (e.g., you requested 200 results using `limit` parameter, but a total of 600 results are available), the `paginationKey` top-level attribute is added to the response. The key corresponds to the `requestId` of the last returned event. In the following request, use that value in the `paginationKey` parameter to get the next page of results:
 
             1. First request, returning most recent 200 events: `GET api-base-url/visitors/:visitorId?limit=200`
-            2. Use response.lastTimestamp to get the next page of results: `GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567`
+            2. Use `response.paginationKey` to get the next page of results: `GET api-base-url/visitors/:visitorId?limit=200&paginationKey=1683900801733.Ogvu1j`
 
-
-            Pagination happens during scanning and before filtering, so you can get less visits than the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
+            Pagination happens during scanning and before filtering, so you can get less visits than the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `paginationKey` attribute is not returned.
+          schema:
+            type: string
+          required: false
+           # example: 1683900801733.Ogvu1j
+        - name: before
+          description: | 
+            ⚠️ Deprecated pagination method, please use `paginationKey` instead. Timestamp (in milliseconds since epoch) used to paginate results. 
           in: query
           schema:
             type: integer
@@ -556,12 +561,13 @@ components:
               - required:
                 - tag
         lastTimestamp:
-          description: When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), a special `lastTimestamp` top-level attribute is added to the response. If you want to paginate the results further in the past, you should use the value of this attribute.
+          description: |
+            ⚠️ Deprecated paging attribute, please use `paginationKey` instead. Timestamp of the last visit in the current page of results.
           type: integer
           format: int64
           example: 1654815517198
         paginationKey:
-          description: Visit's `requestId` of the last visit in the current page.
+          description: Request ID of the last visit in the current page of results. Use this value in the following request as the `paginationKey` parameter to get the next page of results.
           type: string
           example: '1654815517198.azN4IZ'
       required:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -9,50 +9,14 @@ info:
     name: Fingerprint Support
     email: support@fingerprint.com
 tags:
-  - name: Fingerprint
-    externalDocs:
-      url: https://dev.fingerprint.com/docs/server-api
+  - name: Events
+    # externalDocs:
+    #   url: https://dev.fingerprint.com/docs/server-api
     description: |
-      API documentation
-
-      ## Sure but what if this description was very long
-
-      I can use mardown here and **bold** text or *italic* text or `code` text
-
-      even lists:
-
-      - item 1
-      - item 2
-      - item 3
-
-      an tables
-
-      | Column 1 | Column 2 | Column 3 |
-      | -------- | -------- | -------- |
-      | Text     | Text     | Text     |
-      | Text     | Text     | Text     |
-
-      and subheadings
-
-      ## Subheading 1
-
-      ### Subheading 2
-
-      #### Subheading 3
-
-      some content
-
-      ##### Subheading 4
-
-      maybe code blocks
-
-      ```javascript
-      const a = 1;
-      const b = 2;
-      const c = a + b;
-      console.log(c);
-      ```
-
+      Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
+  - name: Visitors
+    description: |
+      Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -67,7 +31,7 @@ paths:
   /events/{request_id}:
     get:
       tags:
-        - Fingerprint
+        - Events
       summary: Get event by requestId
       description: This endpoint allows you to get events with all the information from each activated product (Fingerprint Pro or Bot Detection). Use the requestId as a URL path :request_id parameter. This API method is scoped to a request, i.e. all returned information is by requestId.
       operationId: 'getEvent'
@@ -124,7 +88,7 @@ paths:
   /visitors/{visitor_id}:
     get:
       tags:
-        - Fingerprint
+        - Visitors
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |
@@ -283,26 +247,6 @@ paths:
                 example:
                   summary: Example too many requests error response
                   externalValue: '/examples/visits_too_many_requests_error.json'
-  /webhook:
-    post:
-      tags:
-        - Fingerprint
-      summary: Webhook from Fingerprint to your server
-      description: | 
-        You can configure webhooks to receive identification events as POST requests on your server. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
-        You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WebhookVisit'
-            example:
-              externalValue: '/examples/webhook.json'
-      responses:
-        200:
-          description: |
-            Return 200 OK to indicate that the data was received successfully. 
-            Every request is retried once if it timed out or returned a non-2XX response. The retry will take place 5 minutes after the non-2XX response is received or 5 minutes after the timeout takes place.
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -258,6 +258,106 @@ paths:
         #### Headers
 
         * `Retry-After`: Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
+      parameters:
+        - name: visitor_id
+          description: Unique identifier of the visitor issued by Fingerprint Pro.
+          in: path
+          required: true
+          schema:
+            type: string
+          example: uYIm7Ksp5rf00SllPhFp
+        - name: request_id
+          description: | 
+            Filter visits by `requestId`. 
+            
+            Every identification request has a unique identifier associated with it called `requestId`. This identifier is returned to the client in the identification [result](https://dev.fingerprint.com/docs/js-agent#requestid). When you filter visits by `requestId`, only one visit will be returned.
+          in: query
+          schema:
+            type: string
+            # example: 1654815516083.OX6kx8
+        - name: linked_id
+          description: |
+            Filter visits by your custom identifier. 
+            
+            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example: session ID, purchase ID, or transaction ID. You can then use this `linked_id` parameter to retrieve all events associated with your custom identifier.
+          in: query
+          schema:
+            type: string
+          required: false
+           # example: some_id
+        - name: limit
+          description: | 
+            Limit scanned results. 
+            
+            For performance reasons, the API first scans some number of events before filtering them. Use `limit` to specify how many events are scanned before they are filtered by `requestId` or `linkedId`. Results are always returned sorted by the timestamp (most recent first).
+            By default, the most recent 100 visits are scanned, the maximum is 500. 
+          in: query
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            # default: 0
+            # example: 10
+        - name: before
+          description: | 
+            Timestamp (in milliseconds since epoch) used to paginate results. 
+
+            When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
+            You can use this attribute to get the next page of results — the visits that happened before that timestamp.
+
+            1. First request, returning most recent 200 events: `GET api-base-url/visitors/:visitorId?limit=200`
+            2. Use response.lastTimestamp to get the next page of results: `GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567`
+
+
+            Pagination happens during scanning and before filtering, so you can get less visits than the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            # default: 0
+            # example: 1654815517198
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+              examples:
+                limit1:
+                  summary: Request with limit=1
+                  externalValue: '/examples/visits_limit_1.json'
+                limit500:
+                  summary: Request with limit=500
+                  externalValue: '/examples/visits_limit_500.json'
+        '403':
+          description: Forbidden. The API Key is probably missing or incorrect.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorVisits403'
+              examples:
+                example:
+                  summary: Forbidden
+                  externalValue: '/examples/visits_403_error.json'
+        '429':
+          description: Too Many Requests
+          headers:
+            Retry-After:
+              description: Indicates how long you should wait before attempting the next request.
+              schema:
+                type: integer
+                format: int32
+                minimum: 0
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManyRequestsResponse'
+              examples:
+                example:
+                  summary: Example too many requests error response
+                  externalValue: '/examples/visits_too_many_requests_error.json'
       x-readme:
         code-samples:
           - language: node
@@ -407,106 +507,6 @@ paths:
               // Get visit history of a specific visitor
               var visits = api.GetVisits("VISITOR_ID");
               Console.WriteLine(visits);
-      parameters:
-        - name: visitor_id
-          description: Unique identifier of the visitor issued by Fingerprint Pro.
-          in: path
-          required: true
-          schema:
-            type: string
-          example: uYIm7Ksp5rf00SllPhFp
-        - name: request_id
-          description: | 
-            Filter visits by `requestId`. 
-            
-            Every identification request has a unique identifier associated with it called `requestId`. This identifier is returned to the client in the identification [result](https://dev.fingerprint.com/docs/js-agent#requestid). When you filter visits by `requestId`, only one visit will be returned.
-          in: query
-          schema:
-            type: string
-            # example: 1654815516083.OX6kx8
-        - name: linked_id
-          description: |
-            Filter visits by your custom identifier. 
-            
-            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example: session ID, purchase ID, or transaction ID. You can then use this `linked_id` parameter to retrieve all events associated with your custom identifier.
-          in: query
-          schema:
-            type: string
-          required: false
-           # example: some_id
-        - name: limit
-          description: | 
-            Limit scanned results. 
-            
-            For performance reasons, the API first scans some number of events before filtering them. Use `limit` to specify how many events are scanned before they are filtered by `requestId` or `linkedId`. Results are always returned sorted by the timestamp (most recent first).
-            By default, the most recent 100 visits are scanned, the maximum is 500. 
-          in: query
-          schema:
-            type: integer
-            format: int32
-            minimum: 0
-            # default: 0
-            # example: 10
-        - name: before
-          description: | 
-            Timestamp (in milliseconds since epoch) used to paginate results. 
-
-            When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
-            You can use this attribute to get the next page of results — the visits that happened before that timestamp.
-
-            1. First request, returning most recent 200 events: `GET api-base-url/visitors/:visitorId?limit=200`
-            2. Use response.lastTimestamp to get the next page of results: `GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567`
-
-
-            Pagination happens during scanning and before filtering, so you can get less visits than the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
-          in: query
-          schema:
-            type: integer
-            format: int64
-            minimum: 0
-            # default: 0
-            # example: 1654815517198
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-              examples:
-                limit1:
-                  summary: Request with limit=1
-                  externalValue: '/examples/visits_limit_1.json'
-                limit500:
-                  summary: Request with limit=500
-                  externalValue: '/examples/visits_limit_500.json'
-        '403':
-          description: Forbidden. The API Key is probably missing or incorrect.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorVisits403'
-              examples:
-                example:
-                  summary: Forbidden
-                  externalValue: '/examples/visits_403_error.json'
-        '429':
-          description: Too Many Requests
-          headers:
-            Retry-After:
-              description: Indicates how long you should wait before attempting the next request.
-              schema:
-                type: integer
-                format: int32
-                minimum: 0
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ManyRequestsResponse'
-              examples:
-                example:
-                  summary: Example too many requests error response
-                  externalValue: '/examples/visits_too_many_requests_error.json'
   /webhook:
     trace:
       tags:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -274,7 +274,7 @@ paths:
           description: | 
             Filter visits by `requestId`. 
             
-            Every identification request has a unique identifier, associated with it, called `requestId`. This identifier is returned to the client in the API call response. When you filter visits by `requestId`, only one visit will be returned.
+            Every identification request has a unique identifier associated with it called `requestId`. This identifier is returned to the client in the API call response. When you filter visits by `requestId`, only one visit will be returned.
           in: query
           schema:
             type: string
@@ -283,7 +283,7 @@ paths:
           description: |
             Filter visits by your custom identifier. 
             
-            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example, session ID, purchase ID or transaction ID. You can then use this `linked_id` parameter to retrieve all visits associated with your custom identifier.
+            You can use [`linkedId`](https://dev.fingerprint.com/docs/js-agent#linkedid) to associate identification requests with your own identifier, for example: session ID, purchase ID, or transaction ID. You can then use this `linked_id` parameter to retrieve all visits associated with your custom identifier.
           in: query
           schema:
             type: string
@@ -307,7 +307,7 @@ paths:
             Timestamp (in milliseconds since epoch) used to paginate results. 
 
             When more results are available (e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available), the `lastTimestamp` top-level attribute is added to the response.
-            You can use the value of this attribute to get the next page of results further in the past, to return the visits that happened before that timestamp.
+            You can use this attribute to get the next page of results — the visits that happened before that timestamp.
 
             ```
             // 1st request, returning most recent 200 events:
@@ -316,8 +316,7 @@ paths:
             GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567
             ```
 
-            Pagination happens during scanning and before filtering, so you can get less visits that the `limit` you specified with more available on the next page. 
-            When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
+            Pagination happens during scanning and before filtering, so you can get less visits that the `limit` you specified with more available on the next page. When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
           in: query
           schema:
             type: integer
@@ -498,7 +497,7 @@ components:
           description: Unique identifier of the user's identification request.
           type: string
           example: '1654815516083.OX6kx8'
-        browserDetails:
+        browser Details:
           $ref: '#/components/schemas/BrowserDetails'
         incognito:
           description: Flag if user used incognito session.
@@ -736,7 +735,7 @@ components:
               $ref: '#/components/schemas/BotdError'
 
     EventResponse:
-      description: Contains event from activated products - Fingerprint Pro or Bot Detection
+      description: Contains event from all activated products - Fingerprint Pro, Bot Detection, AEV
       type: object
       additionalProperties: false
       properties:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -95,113 +95,230 @@ paths:
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |
-        This endpoint allows you to get a history of visits with all available information. Use the `visitorId` as a URL path parameter. 
-        This API method is scoped to a visitor, i.e. all returned information is by visitorId.
+        This endpoint allows you to get a history of visits for a specific `visitorId`. Use the `visitorId` as a URL path parameter.
+        Only information from the _Identification_ product is returned.
 
-        I can use mardown here and **bold** text or *italic* text or `code` text 
-        even lists:
-        - item 1
-        - item 2
-        - item 3
+        #### Headers
 
-        an tables 
+        `Retry-After`
 
-        | Column 1 | Column 2 | Column 3 |
-        | -------- | -------- | -------- |
-        | Text     | Text     | Text     |
-        | Text     | Text     | Text     |
-        | Text     | Text     | Text     |
-
-        and subheadings
-
-        ## Subheading 1
-
-        ### Subheading 2
-
-        #### Subheading 3
-         
-        some content
-
-        ##### Subheading 4
-
-        maybe code blocks
-
-        ```javascript
-        const a = 1;
-        const b = 2;
-        const c = a + b;
-        console.log(c);
-        ```
-
-        or links to documentation [Fingerprint Pro](https://fingerprintjs.com/)
+        Indicates how long the user should wait before making a follow-up request.
+        The value is non-negative decimal integer indicating the seconds to delay after the response is received.
       x-readme:
         code-samples:
-          - language: curl
-            code: curl -X POST https://api.example.com/v2/alert
-            name: Custom cURL snippet
-            install: brew install curl
-          - language: php
-            code: <?php echo "This is our custom PHP code snippet."; ?>
-            name: Custom PHP snippet
           - language: node
+            name: Node SDK
+            install: npm install @fingerprintjs/fingerprintjs-pro-server-api
             code: |
-              const axios = require('axios');
-              const data = JSON.stringify({
-                bla: "bla",
-              });
-              const config = {
-                method: 'post',
-                url: 'https://api.example.com/v2/:visitor_id',
-                headers: { 
-                  'Content-Type': 'application/json'
-                },
-                data : data
-              };
-              axios(config);
-            name: Custom Node snippet
+              import {
+                FingerprintJsServerApiClient,
+                Region,
+              } from '@fingerprintjs/fingerprintjs-pro-server-api'
+
+              const client = new FingerprintJsServerApiClient({
+                apiKey: SERVER_API_KEY,
+                region: APP_REGION,
+              })
+
+              // Get visit history of a specific visitor
+              client.getVisitorHistory('VISITOR_ID').then((visitorHistory) => {
+                console.log(visitorHistory)
+              })
+          - language: php
+            name: PHP SDK
+            install: composer require fingerprint/fingerprint-pro-server-api-sdk
+            code: |
+              <?php
+              require_once(__DIR__ . '/vendor/autoload.php');
+              use Fingerprint\ServerAPI\Api\FingerprintApi;
+              use Fingerprint\ServerAPI\Configuration;
+              use GuzzleHttp\Client;
+
+              $config = Configuration::getDefaultConfiguration(
+                SERVER_API_KEY,
+                REGION
+              );
+
+              $client = new FingerprintApi(
+                new Client(),
+                $config
+              );
+
+              // Get visit history of a specific visitor
+              try {
+                $response = $client->getVisits("<visitorId>");
+                echo "<pre>" . $response->__toString() . "</pre>";
+              } catch (Exception $e) {
+                echo $e->getMessage(), PHP_EOL;
+              }
+          - language: python
+            name: Python SDK
+            install: pip install fingerprint_pro_server_api_sdk
+            code: |
+              import fingerprint_pro_server_api_sdk
+              from fingerprint_pro_server_api_sdk import EventResponse
+              from fingerprint_pro_server_api_sdk import Response
+              from fingerprint_pro_server_api_sdk.rest import ApiException
+
+              configuration = fingerprint_pro_server_api_sdk.Configuration(
+                api_key=SERVER_API_KEY,
+                region=REGION
+              )
+              api_instance = fingerprint_pro_server_api_sdk.FingerprintApi(configuration)
+
+              # Get visit history of a specific visitor
+              try:
+                visits: Response = api_instance.get_visits("<visitorId>", limit=10)
+                print(visits)
+              except ApiException as e:
+                print("Exception when getting visits: %s\n" % e)
+          - language: golang
+            name: Go SDK
+            install: go get github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk
+            code: |
+              package main
+
+              import (
+                "context"
+                "fmt"
+                "github.com/antihax/optional"
+                "github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v3/sdk"
+                "log"
+              )
+
+              func main() {
+                cfg := sdk.NewConfiguration()
+                client := sdk.NewAPIClient(cfg)
+
+                auth := context.WithValue(
+                  context.Background(),
+                  sdk.ContextAPIKey,
+                  sdk.APIKey{Key: <SERVER_API_KEY>},
+                )
+                cfg.ChangeRegion(<REGION>)
+
+                // Get visit history of a specific visitor
+                getVisitsOpts := sdk.FingerprintApiGetVisitsOpts{
+                  Limit: optional.NewInt32(10),
+                }
+                history, historyHttpRes, historyErr :=
+                  client.FingerprintApi.GetVisits(auth, "<visitorId", &getVisitsOpts)
+                if err != nil {
+                  log.Fatal(err)
+                }
+                fmt.Printf("Visitor history: %s", history)
+              }
+          - language: java
+            name: Java SDK
+            code: | 
+              import com.fingerprint.api.FingerprintApi;
+              import com.fingerprint.models.EventResponse;
+              import com.fingerprint.models.Response;
+              import com.fingerprint.sdk.ApiClient;
+              import com.fingerprint.sdk.ApiException;
+              import com.fingerprint.sdk.Configuration;
+              import com.fingerprint.sdk.Region;
+
+              public class FingerprintApiExample {
+                public static void main(String... args) {
+                  ApiClient client = Configuration.getDefaultApiClient(
+                    <SERVER_API_KEY>,
+                    <REGION>
+                  );
+                  FingerprintApi api = new FingerprintApi(client);
+
+                  // Get visit history of a specific visitor
+                  try {
+                    Response response = api.getVisits("<visitorID>");
+                    System.out.println(response.getVisits().toString());
+                  } catch (ApiException e) {
+                    System.err.println(e.getMessage());
+                  }
+                }
+              }
+          - language: csharp
+            name: C# SDK
+            install: dotnet add package FingerprintPro.ServerSdk
+            code: |
+              using FingerprintPro.ServerSdk.Api;
+              using FingerprintPro.ServerSdk.Client;
+
+              var configuration = new Configuration(<SERVER_API_KEY>);
+              configuration.Region = <REGION>;
+
+              var api = new FingerprintApi(
+                  configuration
+              );
+
+              // Get visit history of a specific visitor
+              var visits = api.GetVisits("<visitorId>");
+              Console.WriteLine(visits);
       parameters:
         - name: visitor_id
+          description: Unique identifier of the visitor.
           in: path
           required: true
           schema:
             type: string
           example: uYIm7Ksp5rf00SllPhFp
         - name: request_id
-          description: Filter visits by requestId
+          description: | 
+            Every identification event has a unique identifier, associated with it, called `requestId`. This identifier is returned back into the browser during the identification API call and is also available in API responses.  
+            It is a convenient way to return the exact identification event that you need. When you filter events with `requestId`, only one event will be returned, because every event has a unique `requestId`.
           in: query
           schema:
             type: string
-        #          example: 1654815516083.OX6kx8
+            # example: 1654815516083.OX6kx8
         - name: linked_id
           description: |
-            Filter visits by custom identifier
-
-            If you need to associate events with your own identifier, use linkedId. 
-            You can use it in different scenarios: e.g., identify by sessionID, 
-            identify by purchaseID or by your custom transaction number. 
-            You should use requestId to get a single event, whereas you should use linkedId to retrieve several events,
-            associated with your custom identifier.
-
-            *bold* 
-
-            - dkeow
-            - dkeow
+            If you need to associate events with your own identifier, use `linkedId`. You can use it in different scenarios: e.g., identify by sessionID, identify by purchaseID or by your custom transaction number.
+            You should use `requestId` to get a single event, whereas you should use `linkedId` to retrieve several events, associated with your custom identifier.
           in: query
           schema:
             type: string
           required: false
-        #          example: some_id
+           # example: some_id
         - name: limit
-          description: Limit scanned results
+          description: | 
+            For performance reasons, visitors API first performs events scanning and then filtering. Filtering always happens after the results are scanned.  
+            `Limit` is a parameter to specify how many events should be scanned. Results are always returned sorted by the timestamp in descending order \(most recent first\), so scanning the results limits how many events are scanned back in the past.  
+            By default, the visits API scans 100 events. However you can specify a different `limit` parameter, to scan fewer or more results. A maximum value of 500 results can be scanned and returned.
+            After the results were scanned, the filtering is applied to them, e.g., filtering by `requestId` or by `linkedId`.
+
+            **Using limit example**: your website visitor was identified 120 times and 120 events are stored in our database. Last 10 events are associated with a sessionID = 1234ADF; You want to scan last 50 events and filter them by your sessionID = 1234ADF. You can achieve this by using this query:  
+
+            ```
+            GET api-base-url/visitors/:visitorId?limit=50&linked_id=1234ADF
+            ```
+
+            Only 10 rows from the most recent 50 will be returned.
           in: query
           schema:
             type: integer
             format: int32
             minimum: 0
-        #            default: 0
-        #          example: 10
+            # default: 0
+            # example: 10
         - name: before
-          description: Timestamp (in milliseconds since epoch) used to paginate results
+          description: | 
+            Timestamp (in milliseconds since epoch) used to paginate results.
+
+            When more results are available \(e.g., you scanned 200 results using `limit` parameter, but a total of 600 results are available\), a special `lastTimestamp` top-level attribute is added to the response. You should use the value of this attribute, if you want to paginate the results further in the past, to return the events that happened before that timestamp.
+
+            Example of using `before` parameter:
+
+            ```
+            // 1st request, returning most recent 200 events:
+            GET api-base-url/visitors/:visitorId?limit=200
+            // Note that the response has lastTimestamp attribute in the response.
+            // Use that attribute to return the events that happened before, i.e
+            // next page of 200 events
+            GET api-base-url/visitors/:visitorId?limit=200&before=1582232027567
+            ```
+
+            Note that pagination happens during scanning of the results, so if you used pagination + filtering, 
+            you can have just a few results back, with potentially more results available for pagination. These timestamps are stored with a millisecond precision. 
+            When there are no more results available for scanning, the `lastTimestamp` attribute will not be returned.
           in: query
           schema:
             type: integer

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -116,7 +116,31 @@ paths:
         ```
 
         or links to documentation [Fingerprint Pro](https://fingerprintjs.com/)
-
+      x-readme:
+        code-samples:
+          - language: curl
+            code: curl -X POST https://api.example.com/v2/alert
+            name: Custom cURL snippet
+            install: brew install curl
+          - language: php
+            code: <?php echo "This is our custom PHP code snippet."; ?>
+            name: Custom PHP snippet
+          - language: node
+            code: |
+              const axios = require('axios');
+              const data = JSON.stringify({
+                bla: "bla",
+              });
+              const config = {
+                method: 'post',
+                url: 'https://api.example.com/v2/alert',
+                headers: { 
+                  'Content-Type': 'application/json'
+                },
+                data : data
+              };
+              axios(config);
+            name: Custom Node snippet
       parameters:
         - name: visitor_id
           in: path

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -32,13 +32,16 @@ paths:
     get:
       tags:
         - Events
-      summary: Get event by requestId
-      description: This endpoint allows you to get events with all the information from each activated product (Fingerprint Pro or Bot Detection). Use the requestId as a URL path :request_id parameter. This API method is scoped to a request, i.e. all returned information is by requestId.
+      summary: Get event by `requestId`
+      description: | 
+        # `GET` **/events/:requestId**
+        This endpoint allows you to get events with all the information from each activated product (Identification, Bot Detection, AEV). Use `requestId` as the URL path `:request_id` parameter. 
+        This API method is scoped to a request, i.e. all returned information is by `requestId`.
       operationId: 'getEvent'
       parameters:
         - name: request_id
           in: path
-          description: requestId is the unique identifier of each request
+          description: The unique identifier of each fingerprinting event
           required: true
           schema:
             type: string

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -9,12 +9,12 @@ info:
     name: Fingerprint Support
     email: support@fingerprint.com
 tags:
-  - name: Events
+  - name: Fingerprint
     description: |
-      Using the Server API you can retrieve information about individual analysis events using the event's `requestId`.
-  - name: Visitors
-    description: |
-      Using the Server API you can retrieve visitor history of individual visitors using their `visitorId`.
+      Using the Server API you can retrieve information about individual analysis events or event history of individual visitors.
+    externalDocs:
+      description: API documentation
+      url: https://dev.fingerprint.com/reference/pro-server-api
 servers:
   - url: https://api.fpjs.io
     description: Global
@@ -38,7 +38,7 @@ paths:
   /events/{request_id}:
     get:
       tags:
-        - Events
+        - Fingerprint
       operationId: 'getEvent'
       summary: Get event by requestId
       description: | 
@@ -248,7 +248,7 @@ paths:
   /visitors/{visitor_id}:
     get:
       tags:
-        - Visitors
+        - Fingerprint
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |

--- a/utils/convertOpenApiToJsonSchema.js
+++ b/utils/convertOpenApiToJsonSchema.js
@@ -1,6 +1,12 @@
 import { walkJson } from './walkJson.js';
 import { replaceAllOf } from './replaceAllOf.js';
 
+/**
+ *
+ * @param {Object} apiDefinition
+ * @param {string} schemaRef
+ * @returns
+ */
 export function convertOpenApiToJsonSchema(apiDefinition, schemaRef) {
   return {
     type: 'object',
@@ -10,6 +16,11 @@ export function convertOpenApiToJsonSchema(apiDefinition, schemaRef) {
   };
 }
 
+/**
+ *
+ * @param {Object} components
+ * @returns
+ */
 function componentsToDefenitions(components) {
   // Move schemas from components/schemas to definitions path
   walkJson(components, '$ref', (json) => {

--- a/utils/transformers/removeTagsTransformer.js
+++ b/utils/transformers/removeTagsTransformer.js
@@ -1,8 +1,0 @@
-import { walkJson } from '../walkJson.js';
-
-// Removes all tags to prevent Readme API explorer from grouping endpoints by tags unnecessarily
-export function removeTagsTransformer(apiDefinition) {
-  walkJson(apiDefinition, 'tags', (json) => {
-    delete json.tags;
-  });
-}

--- a/utils/transformers/removeTagsTransformer.js
+++ b/utils/transformers/removeTagsTransformer.js
@@ -1,0 +1,8 @@
+import { walkJson } from '../walkJson.js';
+
+// Removes all tags to prevent Readme API explorer from grouping endpoints by tags unnecessarily
+export function removeTagsTransformer(apiDefinition) {
+  walkJson(apiDefinition, 'tags', (json) => {
+    delete json.tags;
+  });
+}

--- a/utils/transformers/removeWebhookTransformer.js
+++ b/utils/transformers/removeWebhookTransformer.js
@@ -1,0 +1,3 @@
+export function removeWebhookTransformer(apiDefinition) {
+  delete apiDefinition.paths['/webhook'];
+}

--- a/utils/transformers/removeWebhookTransformer.js
+++ b/utils/transformers/removeWebhookTransformer.js
@@ -1,3 +1,4 @@
+// Removes the fake webhook endpoint from the API definition to prevent Readme API explorer from showing it
 export function removeWebhookTransformer(apiDefinition) {
   delete apiDefinition.paths['/webhook'];
 }

--- a/utils/transformers/replaceTagsTransformer.js
+++ b/utils/transformers/replaceTagsTransformer.js
@@ -1,0 +1,20 @@
+import { walkJson } from '../walkJson.js';
+
+// Removes tags used by the Readme.com API explorer
+// and applies a single "Fingerprint" tag to all paths, to be consumed by SDK generators.
+export function replaceTagsTransformer(apiDefinition) {
+  apiDefinition.tags = [
+    {
+      name: 'Fingerprint',
+      description:
+        'Using the Server API you can retrieve information about individual analysis events or event history of individual visitors.',
+      externalDocs: {
+        description: 'API documentation',
+        url: 'https://dev.fingerprint.com/reference/pro-server-api',
+      },
+    },
+  ];
+  walkJson(apiDefinition.paths, 'tags', (json) => {
+    json.tags = ['Fingerprint'];
+  });
+}

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -2,10 +2,11 @@ import yaml from 'js-yaml';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
 import { removeWebhookTransformer } from './removeWebhookTransformer.js';
-import { removeTagsTransformer } from './removeTagsTransformer.js';
+import { replaceTagsTransformer } from './replaceTagsTransformer.js';
 
-const defaultTransformers = [resolveExternalValueTransformer, resolveAllOfTransformer];
-export const readmeApiExplorerTransformers = [...defaultTransformers, removeWebhookTransformer, removeTagsTransformer];
+const commonTransformers = [resolveExternalValueTransformer, resolveAllOfTransformer];
+const defaultTransformers = [...commonTransformers, replaceTagsTransformer];
+export const readmeApiExplorerTransformers = [...commonTransformers, removeWebhookTransformer];
 
 export function transformSchema(content, transformers = defaultTransformers) {
   const apiDefinition = yaml.load(content);

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -1,8 +1,10 @@
 import yaml from 'js-yaml';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
+import { removeWebhookTransformer } from './removeWebhookTransformer.js';
 
 const defaultTransformers = [resolveExternalValueTransformer, resolveAllOfTransformer];
+export const readmeApiExplorerTransformers = [...defaultTransformers, removeWebhookTransformer];
 
 export function transformSchema(content, transformers = defaultTransformers) {
   const apiDefinition = yaml.load(content);

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -2,9 +2,10 @@ import yaml from 'js-yaml';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
 import { removeWebhookTransformer } from './removeWebhookTransformer.js';
+import { removeTagsTransformer } from './removeTagsTransformer.js';
 
 const defaultTransformers = [resolveExternalValueTransformer, resolveAllOfTransformer];
-export const readmeApiExplorerTransformers = [...defaultTransformers, removeWebhookTransformer];
+export const readmeApiExplorerTransformers = [...defaultTransformers, removeWebhookTransformer, removeTagsTransformer];
 
 export function transformSchema(content, transformers = defaultTransformers) {
   const apiDefinition = yaml.load(content);

--- a/utils/walkJson.js
+++ b/utils/walkJson.js
@@ -1,3 +1,8 @@
+/**
+ * @param {Object} json
+ * @param {string} key
+ * @param {Function} callback
+ */
 export function walkJson(json, key, callback) {
   Object.keys(json).forEach((iteratorKey) => {
     if (iteratorKey === key) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,8 +63,8 @@ export default {
           transform: (content) => transformSchema(content),
         },
         {
-          from: 'schemas',
-          to: 'schemas/readme-api-explorer/',
+          from: 'schemas/fingerprint-server-api.yaml',
+          to: 'schemas/fingerprint-server-api-readme-explorer.yaml',
           transform: (content) => transformSchema(content, readmeApiExplorerTransformers),
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import 'dotenv/config';
-import { transformSchema } from './utils/transformers/transformSchema.js';
+import { readmeApiExplorerTransformers, transformSchema } from './utils/transformers/transformSchema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -61,6 +61,11 @@ export default {
           from: 'schemas',
           to: 'schemes', // backward compatibility
           transform: (content) => transformSchema(content),
+        },
+        {
+          from: 'schemas',
+          to: 'schemas/readme-api-explorer/',
+          transform: (content) => transformSchema(content, readmeApiExplorerTransformers),
         },
         {
           from: 'examples',


### PR DESCRIPTION
1. Added longer descriptions for endpoints and parameters taking content from https://dev.fingerprint.com/docs/server-api
2. Split tags into `Events` and `Visitors`. Otherwise, Readme would group the two endpoints under a single "Fingerprint" tag/page which was confusing. If this breaks something, let me know, and we can find another solution. 
3. Shortened response example summaries, otherwise the main info was getting cut off by the limited with of Readme's explorer
4. Added SKD code examples. It's another place we have to maintain them but there is value in having them right in the API reference. We are also kind of forced to do this, because Readme autogenerates code snippets for a bunch of languages, and we cannot turn that off, only overwrite specific languages with our own SDK snippets. If we didn't do this it would look like we have do SDKs at all. 
5. Adjusted webpack to build another schema file just for the Readme API explorer and remove the fake `/webhook` endpoint from that one.
6. Deprecated `before`, and documented `paginationKey` instead.

You can see the result reference here: https://dev.fingerprint.com/reference/pro-server-api (must be logged in to Readme).

Commit history is messy, let's squash and merge. 
