### PR TITLE
Document behavior of visitorId when bot is detected on Pro Plus

### DIFF
--- a/examples/get_event_pro_plus_bot_detected.json
+++ b/examples/get_event_pro_plus_bot_detected.json
@@ -2,7 +2,7 @@
   "products": {
     "identification": {
       "data": {
-        "visitorId": "Ibk1527CUFmcnjLwIs4A9",
+        "visitorId": "BotDetected000000000",
         "requestId": "0KSh65EnVoB85JBmloQK",
         "incognito": true,
         "linkedId": "somelinkedId",
@@ -10,49 +10,27 @@
         "timestamp": 1582299576512,
         "url": "https://www.example.com/login",
         "ip": "61.127.217.15",
-        "ipLocation": {
-          "accuracyRadius": 10,
-          "latitude": 49.982,
-          "longitude": 36.2566,
-          "postalCode": "61202",
-          "timezone": "Europe/Dusseldorf",
-          "city": {
-            "name": "Dusseldorf"
-          },
-          "continent": {
-            "code": "EU",
-            "name": "Europe"
-          },
-          "country": {
-            "code": "DE",
-            "name": "Germany"
-          },
-          "subdivisions": [
-            {
-              "isoCode": "63",
-              "name": "North Rhine-Westphalia"
-            }
-          ]
-        },
+        "ipLocation": {},
         "browserDetails": {
-          "browserName": "Chrome",
-          "browserMajorVersion": "74",
-          "browserFullVersion": "74.0.3729",
-          "os": "Windows",
-          "osVersion": "7",
-          "device": "Other",
+          "browserName": "",
+          "browserMajorVersion": "",
+          "browserFullVersion": "",
+          "os": "",
+          "osVersion": "",
+          "device": "",
           "userAgent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) ...."
         },
         "confidence": {
-          "score": 0.97
+          "score": 0.5,
+          "comment": "The real score is unknown"
         },
-        "visitorFound": true,
+        "visitorFound": false,
         "firstSeenAt": {
-          "global": "2022-03-16T11:26:45.362Z",
-          "subscription": "2022-03-16T11:31:01.101Z"
+          "global": null,
+          "subscription": null
         },
         "lastSeenAt": {
-          "global": "2022-03-16T11:28:34.023Z",
+          "global": null,
           "subscription": null
         }
       }
@@ -60,7 +38,8 @@
     "botd": {
       "data": {
         "bot": {
-          "result": "notDetected"
+          "result": "bad",
+          "type": "selenium"
         },
         "url": "https://www.example.com/login",
         "ip": "61.127.217.15",
@@ -145,66 +124,6 @@
       "data": {
         "result": false,
         "anomalyScore": 0
-      }
-    },
-    "clonedApp": {
-      "data": {
-        "result": false
-      }
-    },
-    "factoryReset": {
-      "data": {
-        "time": "1970-01-01T00:00:00Z",
-        "timestamp": 0
-      }
-    },
-    "jailbroken": {
-      "data": {
-        "result": false
-      }
-    },
-    "frida": {
-      "data": {
-        "result": false
-      }
-    },
-    "privacySettings": {
-      "data": {
-        "result": false
-      }
-    },
-    "virtualMachine": {
-      "data": {
-        "result": false
-      }
-    },
-    "rawDeviceAttributes": {
-      "data": {
-        "architecture": {
-          "value": 127
-        },
-        "audio": {
-          "value": 35.73832903057337
-        },
-        "canvas": {
-          "value": {
-            "Winding": true,
-            "Geometry": "4dce9d6017c3e0c052a77252f29f2b1c",
-            "Text": "dd2474a56ff78c1de3e7a07070ba3b7d"
-          }
-        },
-        "colorDepth": {
-          "value": 30
-        },
-        "colorGamut": {
-          "value": "srgb"
-        },
-        "contrast": {
-          "value": 0
-        },
-        "cookiesEnabled": {
-          "value": true
-        }
       }
     }
   }

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -65,6 +65,9 @@ paths:
                 fullResponse:
                   summary: Example response
                   externalValue: '/examples/get_event.json'
+                proPlusBotDetectedResponse:
+                  summary: Bot detected on Pro Plus plan
+                  externalValue: '/examples/get_event_pro_plus_bot_detected.json'
                 allErrorsResponse:
                   summary: All failed signals
                   externalValue: '/examples/get_event_all_errors.json'
@@ -1006,7 +1009,7 @@ components:
           example: 'Hlavni mesto Praha'
     ProductsResponse:
       type: object
-      description: Contains all the information from each activated product - Fingerprint Pro or Bot Detection
+      description: Contains all information about the request identified by `requestId`, depending on the pricing plan (Pro, Pro Plus, Enterprise)
       # The true default value for additionalProperties allows extending schema.
       # However, explicit additionalProperties: true breaks swagger-codegen, therefore commented out.
       # additionalProperties: true
@@ -1025,6 +1028,14 @@ components:
                   properties:
                     visitorId:
                       type: string
+                      description: |
+                        String of 20 characters that uniquely identifies the visitor's browser.
+
+                        **Pro Plus:**
+                        If a bot is detected (`products.botd.bot.result != "notDetected"`), the `visitorId` value contains a placeholder string `BotDetected000000000`.
+                      example: 
+                        - Ibk1527CUFmcnjLwIs4A
+                        - BotDetected000000000
                   required:
                     - visitorId
             error:


### PR DESCRIPTION
- Added description to the products payload that documents possible
  values of visitorId for different plans
- Changed `get_events` example to reflect that visitorId isn't a
  placeholder only in case we didn't detect a bot
- Added specific example payload to describe interaction of visitorId
  when bot is detected on the Pro Plus plan
