### PR TITLE
Add DELETE API to fingerprint-server-api.yaml

### DIFF
--- a/.github/actions/test-and-build/action.yml
+++ b/.github/actions/test-and-build/action.yml
@@ -31,6 +31,9 @@ runs:
     - name: Lint
       shell: bash
       run: pnpm lint
+    - name: Lint schema
+      shell: bash
+      run: pnpm lintSchema
     - name: Tests
       shell: bash
       run: pnpm test
@@ -55,7 +58,7 @@ runs:
       shell: bash
       run: pnpm playwright install --with-deps chromium
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - name: Validate schema
+    - name: Validate schema against live API responses 
       shell: bash
       env:
         TEST_SUBSCRIPTIONS: '${{ inputs.testSubscriptions }}'

--- a/bin/validateSchema.ts
+++ b/bin/validateSchema.ts
@@ -182,20 +182,20 @@ async function validateWebhookSchema() {
 }
 
 /**
- * Validates EventError403 schema
+ * Validates ErrorCommon403Response schema
  */
-async function validateEventError403Schema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating EventError403 schema: \n');
-  const eventError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorEvent403Response');
-  const eventError403Validator = ajv.compile(eventError403Schema);
+async function validateCommonError403Schema(testSubscriptions: TestSubscription[]) {
+  console.log('\nValidating CommonError403 schema: \n');
+  const commonError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorCommon403Response');
+  const commonError403Validator = ajv.compile(commonError403Schema);
 
   // Validate against example file
-  ['./examples/get_event_403_error.json'].forEach((examplePath) =>
+  ['./examples/get_event_403_error.json', './examples/delete_visits_403_error.json'].forEach((examplePath) =>
     validateJson({
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
-      validator: eventError403Validator,
-      schemaName: 'EventError403Schema',
+      validator: commonError403Validator,
+      schemaName: 'CommonError403Schema',
     })
   );
 
@@ -215,8 +215,8 @@ async function validateEventError403Schema(testSubscriptions: TestSubscription[]
       validateJson({
         json: error,
         jsonName: `🌐 Live Server API Error Response for '${subscription.name}' > '${subscription.requestId}'`,
-        validator: eventError403Validator,
-        schemaName: 'EventError403Schema',
+        validator: commonError403Validator,
+        schemaName: 'CommonError403Schema',
       });
     }
   }
@@ -344,7 +344,7 @@ async function validateVisitsError429Schema() {
   await validateVisitsResponseSchema(testSubscriptions);
   await validateWebhookSchema();
 
-  await validateEventError403Schema(testSubscriptions);
+  await validateCommonError403Schema(testSubscriptions);
   await validateEventError404Schema(testSubscriptions);
   await validateVisitsError403Schema(testSubscriptions);
   await validateVisitsError429Schema();

--- a/examples/delete_visits_403_error.json
+++ b/examples/delete_visits_403_error.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "FeatureNotEnabled",
+    "message": "feature not enabled"
+  }
+}

--- a/examples/delete_visits_404_error.json
+++ b/examples/delete_visits_404_error.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "VisitorNotFound",
+    "message": "visitor not found"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "webpack-dev-server --open",
     "build": "webpack",
+    "lintSchema": "vacuum lint ./schemas/fingerprint-server-api.yaml -d --errors",
     "validateSchema": "tsx ./bin/validateSchema.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
@@ -22,6 +23,7 @@
     "@fingerprintjs/fingerprintjs-pro-server-api": "^3.1.0",
     "@fingerprintjs/prettier-config-dx-team": "^0.1.0",
     "@fingerprintjs/tsconfig-dx-team": "^0.0.2",
+    "@quobix/vacuum": "^0.9.15",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.25",
     "@types/swagger-ui": "^3.52.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   '@fingerprintjs/tsconfig-dx-team':
     specifier: ^0.0.2
     version: 0.0.2
+  '@quobix/vacuum':
+    specifier: ^0.9.15
+    version: 0.9.15
   '@types/jest':
     specifier: ^29.5.12
     version: 29.5.12
@@ -1084,6 +1087,16 @@ packages:
   /@pkgr/core@0.1.1:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dev: true
+
+  /@quobix/vacuum@0.9.15:
+    resolution: {integrity: sha512-kmPjKn3RwOKYwwxVKk7wk92MjpyJ1HdUsDdZQyVb4MrnYSNkn11Q8QXF5Bt64wPNhC5GvFF79y1z4LGEpB/6mw==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      node-fetch: 3.3.2
+      tar: 6.2.1
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -2554,6 +2567,11 @@ packages:
     dev: true
     optional: true
 
+  /chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+    dev: true
+
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
@@ -2826,6 +2844,11 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
     dev: true
 
   /debug@2.6.9:
@@ -3478,6 +3501,14 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    dev: true
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3579,6 +3610,13 @@ packages:
     engines: {node: '>=0.4.x'}
     dev: true
 
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: true
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3603,6 +3641,13 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
+    dev: true
+
+  /fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.3.6
     dev: true
 
   /fs.realpath@1.0.0:
@@ -5029,9 +5074,29 @@ packages:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
+  /minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
+  /minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
     engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
+  /minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
     dev: true
 
   /mkdirp-classic@0.5.3:
@@ -5039,6 +5104,12 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -5134,6 +5205,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: true
 
   /node-forge@1.3.1:
@@ -6570,6 +6650,18 @@ packages:
       readable-stream: 3.6.2
     dev: true
     optional: true
+
+  /tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    dev: true
 
   /terser-webpack-plugin@5.3.10(webpack@5.90.3):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorEvent403Response'
+                $ref: '#/components/schemas/ErrorCommon403Response'
               examples:
                 example:
                   summary: Example response
@@ -540,7 +540,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorVisitsDelete403Response'
+                $ref: '#/components/schemas/ErrorCommon403Response'
+              examples:
+                example:
+                  summary: Example response
+                  externalValue: '/examples/delete_visits_403_error.json'
         '404':
           description: Not found. The visitor ID cannot be found in this application's data.
           content:
@@ -614,28 +618,30 @@ components:
         - visits
       title: PaginatedResponse
       description: Fields `lastTimestamp` and `paginationKey` added when `limit` or `before` parameter provided and there is more data to show
-    ErrorEvent403Response:
+    ErrorCommon403Response:
       type: object
       additionalProperties: false
       properties:
         error:
           type: 'object'
           additionalProperties: false
-          title: ErrorEvent403ResponseError
+          title: Common403ErrorResponse
           properties:
             code:
               type: string
               description: >
                 Error code:
                  * `TokenRequired` - `Auth-API-Key` header is missing or empty
-                 * `TokenNotFound` - subscription not found for specified secret key
-                 * `SubscriptionNotActive` - subscription is not active
-                 * `WrongRegion` - server and subscription region differ
+                 * `TokenNotFound` - No Fingerprint application found for specified secret key
+                 * `SubscriptionNotActive` - Fingerprint application is not active
+                 * `WrongRegion` - server and application region differ
+                 * `FeatureNotEnabled` - this feature (for example, Delete API) is not enabled for your application 
               enum:
                 - TokenRequired
                 - TokenNotFound
                 - SubscriptionNotActive
                 - WrongRegion
+                - FeatureNotEnabled
               example: 'TokenRequired'
             message:
               type: string
@@ -686,26 +692,6 @@ components:
           example: 'request throttled'
       required:
         - error
-    ErrorVisitsDelete403Response:
-      type: object
-      additionalProperties: false
-      properties:
-        error:
-          type: 'object'
-          additionalProperties: false
-          title: ErrorVisitsDelete403Response
-          properties:
-            code:
-              type: string
-              enum:
-                - FeatureNotEnabled
-              description: >
-                This feature is not enabled for your subscription.
-            message:
-              type: string
-          required:
-            - code
-            - message
     ErrorVisitsDelete404Response:
       type: object
       additionalProperties: false

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -42,7 +42,7 @@ paths:
       operationId: 'getEvent'
       summary: Get event by requestId
       description: |
-        This endpoint allows you to get a detailed analysis of an individual request. 
+        Get a detailed analysis of an individual identification event, including Smart Signals. 
         **Only for Enterprise customers:** Please note that the response includes mobile signals (e.g. `rootApps`) even if the request originated from a non-mobile platform.
         It is highly recommended that you **ignore** the mobile signals for such requests. 
 
@@ -253,7 +253,7 @@ paths:
       operationId: 'getVisits'
       summary: Get visits by visitorId
       description: |
-        This endpoint allows you to get a history of visits for a specific `visitorId`. Use the `visitorId` as a URL path parameter.
+        Get a history of visits (identification events) for a specific `visitorId`. Use the `visitorId` as a URL path parameter.
         Only information from the _Identification_ product is returned.
 
         #### Headers

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -40,7 +40,7 @@ paths:
       tags:
         - Events
       operationId: 'getEvent'
-      summary: Get event by requestId
+      summary: Get event by request ID
       description: |
         Get a detailed analysis of an individual identification event, including Smart Signals. 
         **Only for Enterprise customers:** Please note that the response includes mobile signals (e.g. `rootApps`) even if the request originated from a non-mobile platform.
@@ -50,7 +50,7 @@ paths:
       parameters:
         - name: request_id
           in: path
-          description: The unique [identifier](https://dev.fingerprint.com/docs/js-agent#requestid) of each analysis request.
+          description: The unique [identifier](https://dev.fingerprint.com/docs/js-agent#requestid) of each identification request.
           required: true
           schema:
             type: string
@@ -251,7 +251,7 @@ paths:
       tags:
         - Visitors
       operationId: 'getVisits'
-      summary: Get visits by visitorId
+      summary: Get visits by visitor ID
       description: |
         Get a history of visits (identification events) for a specific `visitorId`. Use the `visitorId` as a URL path parameter.
         Only information from the _Identification_ product is returned.
@@ -261,7 +261,7 @@ paths:
         * `Retry-After` — Present in case of `429 Too many requests`. Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
       parameters:
         - name: visitor_id
-          description: Unique identifier of the visitor issued by Fingerprint Pro.
+          description: Unique [visitor identifier](https://dev.fingerprint.com/docs/js-agent#visitorid) issued by Fingerprint Pro.
           in: path
           required: true
           schema:
@@ -520,7 +520,7 @@ paths:
       tags:
         - Visitors
       operationId: 'deleteVisitorData'
-      summary: Delete data for a given visitorId
+      summary: Delete data by visitor ID
       description: |
         Request deleting all data associated with the specified visitor ID. This API is useful for compliance with privacy regulations.
         All delete requests are queued: 

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -522,8 +522,8 @@ paths:
       operationId: 'deleteVisitorData'
       summary: Delete data for a given visitorId
       description: |
-        Use this API to  request that data belonging to the specificvisitorId be deleted. This API is useful for compliance with privacy regulations.
-        All requests to this endpoint will be queued and the data belonging to the requested visitors will be deleted within 24 hrs<sup>*</sup>
+        Request deleting all data belonging to the specified visitor ID. This API is useful for compliance with privacy regulations.
+        All requests to this endpoint will be queued and the data belonging to the requested visitor will be deleted within 24 hrs<sup>*</sup>
         <sup>*</sup>Data from recent events (10 days or newer) will be deleted with 24 hrs. Data from older events will be deleted after 90 days.
       parameters:
         - name: visitor_id
@@ -534,7 +534,7 @@ paths:
             type: string
       responses:
         '200':
-          description: OK. The visitor_id is scheduled for deletion.
+          description: OK. The visitor ID is scheduled for deletion.
         '403':
           description: Forbidden. Access to this API is denied.
           content:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -516,6 +516,36 @@ paths:
               // Get visit history of a specific visitor
               var visits = api.GetVisits("VISITOR_ID");
               Console.WriteLine(visits);
+    delete:
+      tags:
+        - Visitors
+      operationId: 'deleteVisitorData'
+      summary: Delete data for a given visitorId
+      description: |
+        Use this API to  request that data belonging to the specificvisitorId be deleted. This API is useful for compliance with privacy regulations.
+        All requests to this endpoint will be queued and the data belonging to the requested visitors will be deleted within 24 hrs<sup>*</sup>
+        <sup>*</sup>Data from recent events (10 days or newer) will be deleted with 24 hrs. Data from older events will be deleted after 90 days.
+      parameters:
+        - name: visitor_id
+          description: The [visitorId](https://dev.fingerprint.com/docs/js-agent#visitorid) whose data must be deleted.
+          required: true
+          schema:
+            type: string
+          responses:
+            '200':
+              description: OK. The visitor_id is scheduled for deletion.
+            '403':
+              description: Forbidden. Access to this API is denied.
+              content:
+                application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorVisitsDelete403Response'
+            '404':
+              description: Not found. The visitor_id cannot be found in this subscription's data.
+              content:
+                application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorVisitsDelete404Response'
   /webhook:
     trace:
       tags:
@@ -651,6 +681,46 @@ components:
           example: 'request throttled'
       required:
         - error
+    ErrorVisitsDelete403Response:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: 'object'
+          additionalProperties: false
+          title: ErrorVisitsDelete403Response
+          properties:
+            code:
+              type: string
+              enum:
+                - FeatureNotEnabledForSubscription
+              description: >
+                This feature is not enabled for your subscription.
+            message:
+              type: string
+          required:
+            - code
+            - message
+    ErrorVisitsDelete404Response:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: 'object'
+          additionalProperties: false
+          title: ErrorVisitsDelete404ResponseError
+          properties:
+            code:
+              type: string
+              enum:
+                - VisitorNotFound
+              description: >
+                The visitor_id cannot be found in this subscription's data.
+            message:
+              type: string
+          required:
+            - code
+            - message
     WebhookVisit:
       allOf:
         - type: object

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -527,25 +527,26 @@ paths:
         <sup>*</sup>Data from recent events (10 days or newer) will be deleted with 24 hrs. Data from older events will be deleted after 90 days.
       parameters:
         - name: visitor_id
+          in: path
           description: The [visitorId](https://dev.fingerprint.com/docs/js-agent#visitorid) whose data must be deleted.
           required: true
           schema:
             type: string
-          responses:
-            '200':
-              description: OK. The visitor_id is scheduled for deletion.
-            '403':
-              description: Forbidden. Access to this API is denied.
-              content:
-                application/json:
-                schema:
-                  $ref: '#/components/schemas/ErrorVisitsDelete403Response'
-            '404':
-              description: Not found. The visitor_id cannot be found in this subscription's data.
-              content:
-                application/json:
-                schema:
-                  $ref: '#/components/schemas/ErrorVisitsDelete404Response'
+      responses:
+        '200':
+          description: OK. The visitor_id is scheduled for deletion.
+        '403':
+          description: Forbidden. Access to this API is denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorVisitsDelete403Response'
+        '404':
+          description: Not found. The visitor_id cannot be found in this subscription's data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorVisitsDelete404Response'
   /webhook:
     trace:
       tags:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -693,7 +693,7 @@ components:
             code:
               type: string
               enum:
-                - FeatureNotEnabledForSubscription
+                - FeatureNotEnabled
               description: >
                 This feature is not enabled for your subscription.
             message:

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -522,13 +522,15 @@ paths:
       operationId: 'deleteVisitorData'
       summary: Delete data for a given visitorId
       description: |
-        Request deleting all data belonging to the specified visitor ID. This API is useful for compliance with privacy regulations.
-        All requests to this endpoint will be queued and the data belonging to the requested visitor will be deleted within 24 hrs<sup>*</sup>
-        <sup>*</sup>Data from recent events (10 days or newer) will be deleted with 24 hrs. Data from older events will be deleted after 90 days.
+        Request deleting all data associated with the specified visitor ID. This API is useful for compliance with privacy regulations.
+        All delete requests are queued: 
+        
+        * Recent data (10 days or newer) belonging to the specified visitor will be deleted within 24 hours.
+        * Data from older (11 days or more) identification events  will be deleted after 90 days.
       parameters:
         - name: visitor_id
           in: path
-          description: The [visitorId](https://dev.fingerprint.com/docs/js-agent#visitorid) whose data must be deleted.
+          description: The [visitor ID](https://dev.fingerprint.com/docs/js-agent#visitorid) you want to delete.
           required: true
           schema:
             type: string

--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -542,11 +542,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorVisitsDelete403Response'
         '404':
-          description: Not found. The visitor_id cannot be found in this subscription's data.
+          description: Not found. The visitor ID cannot be found in this application's data.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorVisitsDelete404Response'
+              examples:
+                example:
+                  summary: Example 404 response
+                  externalValue: '/examples/delete_visits_404_error.json'
   /webhook:
     trace:
       tags:
@@ -652,7 +656,7 @@ components:
               type: string
               description: >
                 Error code:
-                 * `RequestNotFound` - request not found for specified id
+                 * `RequestNotFound` - The specified request ID was not found. It never existed, expired, or it has been deleted.
               enum:
                 - RequestNotFound
               example: 'RequestNotFound'
@@ -713,12 +717,15 @@ components:
           properties:
             code:
               type: string
+              description: >
+                Error code:
+                * `VisitorNotFound` - The specified visitor ID was not found. It never existed or it may have already been deleted.
               enum:
                 - VisitorNotFound
-              description: >
-                The visitor_id cannot be found in this subscription's data.
+              example: 'VisitorNotFound'
             message:
               type: string
+              example: 'visitor not found'
           required:
             - code
             - message

--- a/utils/mocks/simpleWithDelete.yaml
+++ b/utils/mocks/simpleWithDelete.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Fingerprint server API
+  description: defaultDescription
+  version: '0.1'
+servers:
+  - url: https://api.fpjs.io
+    description: Global
+paths:
+  /visitors/{visitor_id}:
+    get:
+      parameters:
+        - name: visitor_id
+          in: path
+          required: true
+          schema:
+            type: string
+          example: mcEozNgqhKgmfXx7ZaMW
+      responses:
+        '200':
+          description: Auto generated using Swagger Inspector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+    delete: 
+      parameters:
+        - name: visitor_id
+          in: path
+          required: true
+          schema:
+            type: string
+          example: mcEozNgqhKgmfXx7ZaMW
+      responses: 
+        '200':
+          description: Auto generated using Swagger Inspector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+components:
+  schemas:
+    Response:
+      type: object
+      additionalProperties: false
+      properties:
+        visitorId:
+          type: string
+          example: null
+      required:
+        - visitorId
+        - visits
+      title: Response

--- a/utils/transformers/removeDeleteVisitorTransformer.js
+++ b/utils/transformers/removeDeleteVisitorTransformer.js
@@ -1,0 +1,4 @@
+// Removes the fake webhook endpoint from the API definition to prevent Readme API explorer from showing it
+export function removeDeleteVisitorTransformer(apiDefinition) {
+  delete apiDefinition.paths['/visitors/{visitor_id}'].delete;
+}

--- a/utils/transformers/removeDeleteVisitorTransformer.spec.js
+++ b/utils/transformers/removeDeleteVisitorTransformer.spec.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { removeDeleteVisitorTransformer } from './removeDeleteVisitorTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const simpleWithDelete = fs.readFileSync('./utils/mocks/simpleWithDelete.yaml');
+
+const removeDeleteVisitor = (yaml) => transformSchema(yaml, [removeDeleteVisitorTransformer]);
+describe('Test removeDeleteVisitorTransformer', () => {
+  it('don`t need to do anything', () => {
+    const result = removeDeleteVisitor(simpleYaml);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('need to remove delete endpoint', () => {
+    const result = removeDeleteVisitor(simpleWithDelete);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+});

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -5,6 +5,7 @@ import { removeWebhookTransformer } from './removeWebhookTransformer.js';
 import { replaceTagsTransformer } from './replaceTagsTransformer.js';
 import { removeBigExamplesTransformer } from './removeBigExamplesTransformer.js';
 import { removeXReadmeTransformer } from './removeXReadmeTransformer.js';
+import { removeDeleteVisitorTransformer } from './removeDeleteVisitorTransformer.js';
 
 const commonTransformers = [resolveExternalValueTransformer, resolveAllOfTransformer];
 const defaultTransformers = [...commonTransformers, replaceTagsTransformer];
@@ -14,6 +15,13 @@ export const removeExtraDocumentationTransformers = [
   ...defaultTransformers,
   removeBigExamplesTransformer,
   removeXReadmeTransformer,
+];
+
+export const schemaForSdksTransformers = [
+  ...defaultTransformers,
+  removeXReadmeTransformer,
+  removeBigExamplesTransformer,
+  removeDeleteVisitorTransformer,
 ];
 
 export function transformSchema(content, transformers = defaultTransformers) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ import 'dotenv/config';
 import {
   readmeApiExplorerTransformers,
   removeExtraDocumentationTransformers,
+  schemaForSdksTransformers,
   transformSchema,
 } from './utils/transformers/transformSchema.js';
 
@@ -75,6 +76,11 @@ export default {
           from: 'schemas/fingerprint-server-api.yaml',
           to: 'schemas/fingerprint-server-api-compact.yaml',
           transform: (content) => transformSchema(content, removeExtraDocumentationTransformers),
+        },
+        {
+          from: 'schemas/fingerprint-server-api.yaml',
+          to: 'schemas/fingerprint-server-api-schema-for-sdks.yaml',
+          transform: (content) => transformSchema(content, schemaForSdksTransformers),
         },
         {
           from: 'examples',


### PR DESCRIPTION
@leenasudhakar: 

A new API to delete visitor data is being introduced. Please see [ID-755](https://fingerprintjs.atlassian.net/browse/ID-755 ) for additional information. 

[ID-755]: https://fingerprintjs.atlassian.net/browse/ID-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

@JuroUhlar's additions: 

- fixed wrong indentation 
- added basic Lint schema step to CI to catch indentation issues and similar automatically going forward (using `vacuum`)
- unified Event 403 Error and Delete visitor 403 Error into a single `ErrorCommon403Response` schema
  - updated `ValidateSchema.ts` script accordingly
- some small error message wording unifications
- added a `removeDeleteVisitorTransformer` to remove the delete endpoint for the schema provided to Server SDKs for code generation (including associated tests and their mock files)
 