### PR TITLE
Update description for DELETE API

### DIFF
--- a/schemas/fingerprint-server-api.yaml
+++ b/schemas/fingerprint-server-api.yaml
@@ -590,12 +590,29 @@ paths:
       summary: Delete data by visitor ID
       description: |
         Request deleting all data associated with the specified visitor ID. This API is useful for compliance with privacy regulations.
-        All delete requests are queued: 
         
-        * Recent data (10 days or newer) belonging to the specified visitor will be deleted within 24 hours.
-        * Data from older (11 days or more) identification events  will be deleted after 90 days.
+        ### Which data is deleted?
+        - Browser (or device) properties
+        - Identification requests made from this browser (or device)
+        
+        #### Browser (or device) properties
+        - Represents the data that Fingerprint collected from this specific browser (or device) and everything inferred and derived from it.
+        - Upon request to delete, this data is deleted asynchronously (typically within a few minutes) and it will no longer be used to identify this browser (or device) for your [Fingerprint Application](https://dev.fingerprint.com/docs/glossary#fingerprint-application).
+        
+        #### Identification requests made from this browser (or device)
+        - Fingerprint stores the identification requests made from a browser (or device) for up to 30 (or 90) days depending on your plan. To learn more, see [Data Retention](https://dev.fingerprint.com/docs/regions#data-retention).
+        - Upon request to delete, the identification requests that were made by this browser
+          - Within the past 10 days are deleted within 24 hrs.
+          - Outside of 10 days are allowed to purge as per your data retention period.
+          
+        ### Corollary
+        After requesting to delete a visitor ID,
+        - If the same browser (or device) requests to identify, it will receive a different visitor ID.
+        - If you request [`/events` API](https://dev.fingerprint.com/reference/getevent) with a `request_id` that was made outside of the 10 days, you will still receive a valid response.
+        - If you request [`/visitors` API](https://dev.fingerprint.com/reference/getvisits) for the deleted visitor ID, the response will include identification requests that were made outside of those 10 days.
 
-        If you are interested in using this API, please [contact our support team](https://fingerprint.com/support/) to enable it for you. Otherwise, you will receive a 403.
+        ### Interested?
+        Please [contact our support team](https://fingerprint.com/support/) to enable it for you. Otherwise, you will receive a 403.
       parameters:
         - name: visitor_id
           in: path


### PR DESCRIPTION
There were so many questions from PayPal on how the DELETE API works. It made us realize that the documentation needs to be beefed up. It has been reviewed for technical correctness by the Identification team.