### PR TITLE
Apply `x-flatten-optional-params: true` for visitors and webhook paths

### DIFF
--- a/schemas/paths/visitors.yaml
+++ b/schemas/paths/visitors.yaml
@@ -10,6 +10,7 @@ get:
     #### Headers
     
     * `Retry-After` — Present in case of `429 Too many requests`. Indicates how long you should wait before making a follow-up request. The value is non-negative decimal integer indicating the seconds to delay after the response is received.
+  x-flatten-optional-params: true
   parameters:
     - name: visitor_id
       in: path

--- a/schemas/paths/webhook.yaml
+++ b/schemas/paths/webhook.yaml
@@ -15,6 +15,7 @@ trace:
       webhook:
         post:
           description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
+          x-flatten-optional-params: true
           requestBody:
             content:
               application/json:


### PR DESCRIPTION
In Java SDK [we changed how we expect optional arguments in methods](https://github.com/fingerprintjs/fingerprint-pro-server-api-java-sdk/pull/100/files). To keep backward compatibility for existing methods with optional arguments, we need to add `x-flatten-optional-params: true`.