### PR TITLE
fix: apply x-flatten-optional-params: true in the webhook.yaml

### DIFF
--- a/.changeset/shaky-goats-beam.md
+++ b/.changeset/shaky-goats-beam.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': patch
+---
+
+**webhook**: Apply x-flatten-optional-params: true in correct place in the webhook.yaml

--- a/schemas/paths/webhook.yaml
+++ b/schemas/paths/webhook.yaml
@@ -16,7 +16,6 @@ trace:
       webhook:
         post:
           description: You can use HTTP basic authentication and set up credentials in your [Fingerprint account](https://dashboard.fingerprint.com/login)
-          x-flatten-optional-params: true
           requestBody:
             content:
               application/json:

--- a/schemas/paths/webhook.yaml
+++ b/schemas/paths/webhook.yaml
@@ -2,6 +2,7 @@ trace:
   tags:
     - Fingerprint
   description: Fake path to describe webhook format. More information about webhooks can be found in the [documentation](https://dev.fingerprint.com/docs/webhooks)
+  x-flatten-optional-params: true
   requestBody:
     content:
       application/json:


### PR DESCRIPTION
Fix for [failing sync](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/14064117067/job/39428320406schema ). Restores the previously [applied change](https://github.com/fingerprintjs/fingerprint-pro-server-api-java-sdk/commit/02546820229a9cb6fb347bfca5e5c1090d95b197) in the Java SDK