### PR TITLE
Update schema validation INTER-1147

### DIFF
--- a/bin/validateSchema.ts
+++ b/bin/validateSchema.ts
@@ -83,12 +83,27 @@ const REGION_MAP = {
   ap: Region.AP,
 } as const;
 
+function getCurrentFunctionName() {
+  try {
+    throw new Error();
+  } catch (e) {
+    // Parse the stack trace to get the function name
+    const stackLines = e.stack.split('\n');
+    // The calling function is typically at index 2 (after Error and getCurrentFunctionName)
+    const callerLine = stackLines[2];
+    // Extract the function name using regex
+    const match = callerLine.match(/at\s+(.*)\s+\(/);
+    return match ? `${match[1]}()` : 'anonymous';
+  }
+}
+
 /**
  * Validate EventResponse schema
  */
 async function validateEventResponseSchema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating EventResponse schema: \n');
-  const eventResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/EventsGetResponse');
+  const schemaName = 'EventsGetResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const eventResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const eventValidator = ajv.compile(eventResponseSchema);
 
   // Validate against example files
@@ -103,7 +118,7 @@ async function validateEventResponseSchema(testSubscriptions: TestSubscription[]
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: eventValidator,
-      schemaName: 'EventsGetResponse',
+      schemaName,
     })
   );
 
@@ -120,7 +135,7 @@ async function validateEventResponseSchema(testSubscriptions: TestSubscription[]
         json: eventResponse,
         jsonName: `🌐 Live Server API EventResponse for GET event '${subscription.name}' > '${subscription.requestId}'`,
         validator: eventValidator,
-        schemaName: 'EventsGetResponse',
+        schemaName,
       });
     } catch (error) {
       console.error(error);
@@ -133,8 +148,9 @@ async function validateEventResponseSchema(testSubscriptions: TestSubscription[]
  * Validate Visits schema
  */
 export async function validateVisitsResponseSchema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating Visits schema: \n');
-  const visitsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/VisitorsGetResponse');
+  const schemaName = 'VisitorsGetResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}:Validating ${schemaName} schema: \n`);
+  const visitsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitsResponseValidator = ajv.compile(visitsResponseSchema);
 
   // Validate against example files
@@ -146,7 +162,7 @@ export async function validateVisitsResponseSchema(testSubscriptions: TestSubscr
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: visitsResponseValidator,
-      schemaName: 'VisitorsGetResponse',
+      schemaName,
     })
   );
 
@@ -176,8 +192,9 @@ export async function validateVisitsResponseSchema(testSubscriptions: TestSubscr
  * Validates Webhook schema
  */
 async function validateWebhookSchema() {
-  console.log('\nValidating Webhook schema: \n');
-  const webhookSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/Webhook');
+  const schemaName = 'Webhook';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const webhookSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const webhookValidator = ajv.compile(webhookSchema);
 
   // Validate against example file
@@ -186,7 +203,7 @@ async function validateWebhookSchema() {
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: webhookValidator,
-      schemaName: 'Webhook',
+      schemaName,
     })
   );
 }
@@ -195,8 +212,8 @@ async function validateWebhookSchema() {
  * Validates ErrorCommon403Response schema
  */
 async function validateCommonError403Schema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating CommonError403 schema: \n');
   const schemaName = 'ErrorResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const commonError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const commonError403Validator = ajv.compile(commonError403Schema);
 
@@ -291,8 +308,9 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
  * Validate EventError404 schema
  */
 async function validateEventError404Schema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating EventError404 schema: \n');
-  const eventError404Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorResponse');
+  const schemaName = 'ErrorResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const eventError404Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const eventError404Validator = ajv.compile(eventError404Schema);
 
   // Validate against example file
@@ -301,7 +319,7 @@ async function validateEventError404Schema(testSubscriptions: TestSubscription[]
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: eventError404Validator,
-      schemaName: 'ErrorResponse',
+      schemaName,
     })
   );
 
@@ -344,8 +362,9 @@ async function validateEventError404Schema(testSubscriptions: TestSubscription[]
  * Validates VisitsError400 schema
  */
 async function validateGetVisitsError400Schema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating VisitsError400 schema: \n');
-  const visitsError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorPlainResponse');
+  const schemaName = 'ErrorPlainResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const visitsError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitsError400Validator = ajv.compile(visitsError400Schema);
 
   // Validate against example file
@@ -354,7 +373,7 @@ async function validateGetVisitsError400Schema(testSubscriptions: TestSubscripti
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: visitsError400Validator,
-      schemaName: 'ErrorPlainResponse',
+      schemaName,
     })
   );
 
@@ -373,7 +392,7 @@ async function validateGetVisitsError400Schema(testSubscriptions: TestSubscripti
         json: (error as RequestError).responseBody,
         jsonName: `🌐 Live Server API Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: visitsError400Validator,
-        schemaName: 'ErrorPlainResponse',
+        schemaName,
       });
     }
   }
@@ -383,8 +402,9 @@ async function validateGetVisitsError400Schema(testSubscriptions: TestSubscripti
  * Validates VisitsError403 schema
  */
 async function validateGetVisitsError403Schema(testSubscriptions: TestSubscription[]) {
-  console.log('\nValidating VisitsError403 schema: \n');
-  const visitsError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorPlainResponse');
+  const schemaName = 'ErrorPlainResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const visitsError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitsError403Validator = ajv.compile(visitsError403Schema);
 
   // Validate against example file
@@ -393,7 +413,7 @@ async function validateGetVisitsError403Schema(testSubscriptions: TestSubscripti
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: visitsError403Validator,
-      schemaName: 'ErrorPlainResponse',
+      schemaName,
     })
   );
 
@@ -412,7 +432,7 @@ async function validateGetVisitsError403Schema(testSubscriptions: TestSubscripti
         json: (error as RequestError).responseBody,
         jsonName: `🌐 Live Server API Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: visitsError403Validator,
-        schemaName: 'ErrorPlainResponse',
+        schemaName,
       });
     }
   }
@@ -422,8 +442,9 @@ async function validateGetVisitsError403Schema(testSubscriptions: TestSubscripti
  * Validates VisitsError429
  */
 async function validateGetVisitsError429Schema() {
-  console.log('\nValidating VisitsError429 schema: \n');
-  const visitsError429Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorPlainResponse');
+  const schemaName = 'ErrorPlainResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const visitsError429Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitsError429Validator = ajv.compile(visitsError429Schema);
 
   // Validate against example file
@@ -432,7 +453,7 @@ async function validateGetVisitsError429Schema() {
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: visitsError429Validator,
-      schemaName: 'ErrorPlainResponse',
+      schemaName,
     })
   );
 }
@@ -441,8 +462,9 @@ async function validateGetVisitsError429Schema() {
  * Validates ErrorCommon429Response
  */
 async function validateErrorCommon429Response() {
-  console.log('\nValidating ErrorCommon429Response schema: \n');
-  const errorCommon429ResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorResponse');
+  const schemaName = 'ErrorResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const errorCommon429ResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const errorCommon429ResponseValidator = ajv.compile(errorCommon429ResponseSchema);
 
   // Validate against example file
@@ -451,7 +473,7 @@ async function validateErrorCommon429Response() {
       json: JSON.parse(fs.readFileSync(examplePath).toString()),
       jsonName: examplePath,
       validator: errorCommon429ResponseValidator,
-      schemaName: 'ErrorResponse',
+      schemaName,
     })
   );
 }
@@ -461,7 +483,7 @@ async function validateErrorCommon429Response() {
  */
 async function validateErrorVisitor400Response(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const visitorError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitorError400Validator = ajv.compile(visitorError400Schema);
 
@@ -518,7 +540,7 @@ async function validateErrorVisitor400Response(testSubscriptions: TestSubscripti
  */
 async function validateErrorVisitor404Response(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const visitorError404Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const visitorError404Validator = ajv.compile(visitorError404Schema);
 
@@ -570,7 +592,7 @@ async function validateErrorVisitor404Response(testSubscriptions: TestSubscripti
 
 async function validateRelatedVisitorsResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'RelatedVisitorsResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const relatedVisitorsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const relatedVisitorsResponseValidator = ajv.compile(relatedVisitorsResponseSchema);
 
@@ -609,7 +631,7 @@ async function validateRelatedVisitorsResponseSchema(testSubscriptions: TestSubs
  */
 async function validateUpdateEventError400Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const updateEvent400ErrorSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const updateEvent400ErrorValidator = ajv.compile(updateEvent400ErrorSchema);
 
@@ -652,8 +674,8 @@ async function validateUpdateEventError400Schema(testSubscriptions: TestSubscrip
  */
 async function validateUpdateEventError409Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
-  const updateEvent409ErrorSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, '#/definitions/ErrorResponse');
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const updateEvent409ErrorSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const updateEvent409ErrorValidator = ajv.compile(updateEvent409ErrorSchema);
 
   // Validate against example file
@@ -700,7 +722,7 @@ async function validateUpdateEventError409Schema(testSubscriptions: TestSubscrip
 
 async function validateSearchEventsResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'SearchEventsResponse';
-  console.log(`\nValidating ${schemaName} schema: \n`);
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
   const searchEventsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
   const searchEventsResponseValidator = ajv.compile(searchEventsResponseSchema);
 

--- a/bin/validateSchema.ts
+++ b/bin/validateSchema.ts
@@ -271,6 +271,19 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
         schemaName,
       });
     }
+
+    // Validate against SearchEvents API response
+    try {
+      const searchEventsResponse = await client.searchEvents({ limit: 10 });
+      fail(`❌ Request for search-events ${searchEventsResponse} in ${subscription.name} should have failed`);
+    } catch (error) {
+      validateJson({
+        json: (error as RequestError).responseBody,
+        jsonName: `🌐 Live Server API Response for GET search-events '${subscription.name}' > '${subscription.visitorId}'`,
+        validator: commonError403Validator,
+        schemaName,
+      });
+    }
   }
 }
 

--- a/bin/validateSchema.ts
+++ b/bin/validateSchema.ts
@@ -73,6 +73,7 @@ const testSubscriptionEnvVariableZod = z.object({
   // Coerce "true" into true
   deleteEnabled: z.coerce.boolean().optional(),
   relatedVisitorsEnabled: z.coerce.boolean().optional(),
+  botDetectionEnabled: z.coerce.boolean().optional(),
 });
 type TestSubscription = z.infer<typeof testSubscriptionEnvVariableZod> & { requestId: string; visitorId: string };
 
@@ -246,7 +247,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET event '${subscription.name}' > '${subscription.requestId}'`,
+        jsonName: `🌐 Response for GET event '${subscription.name}' > '${subscription.requestId}'`,
         validator: commonError403Validator,
         schemaName,
       });
@@ -258,7 +259,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for PUT event '${subscription.name}' > '${subscription.requestId}'`,
+        jsonName: `🌐 Response for PUT event '${subscription.name}' > '${subscription.requestId}'`,
         validator: commonError403Validator,
         schemaName,
       });
@@ -270,7 +271,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for DELETE visitor '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for DELETE visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: commonError403Validator,
         schemaName,
       });
@@ -283,7 +284,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET related-visitors '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for GET related-visitors '${subscription.name}' > '${subscription.visitorId}'`,
         validator: commonError403Validator,
         schemaName,
       });
@@ -296,7 +297,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET search-events '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for GET search-events '${subscription.name}' > '${subscription.visitorId}'`,
         validator: commonError403Validator,
         schemaName,
       });
@@ -338,7 +339,7 @@ async function validateEventError404Schema(testSubscriptions: TestSubscription[]
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET event '${subscription.name}' > '${nonExistentRequestId}'`,
+        jsonName: `🌐 Response for GET event '${subscription.name}' > '${nonExistentRequestId}'`,
         validator: eventError404Validator,
         schemaName: 'ErrorResponse',
       });
@@ -350,7 +351,7 @@ async function validateEventError404Schema(testSubscriptions: TestSubscription[]
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for PUT event '${subscription.name}' > '${nonExistentRequestId}'`,
+        jsonName: `🌐 Response for PUT event '${subscription.name}' > '${nonExistentRequestId}'`,
         validator: eventError404Validator,
         schemaName: 'ErrorResponse',
       });
@@ -390,7 +391,7 @@ async function validateGetVisitsError400Schema(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: visitsError400Validator,
         schemaName,
       });
@@ -430,7 +431,7 @@ async function validateGetVisitsError403Schema(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for GET visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: visitsError403Validator,
         schemaName,
       });
@@ -514,7 +515,7 @@ async function validateErrorVisitor400Response(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for DELETE visitor '${subscription.name}' > '${subscription.visitorId}'`,
+        jsonName: `🌐 Response for DELETE visitor '${subscription.name}' > '${subscription.visitorId}'`,
         validator: visitorError400Validator,
         schemaName: 'DeleteVisitsError400',
       });
@@ -527,7 +528,7 @@ async function validateErrorVisitor400Response(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET related-visitors '${subscription.name}' > 'badVisitorId'`,
+        jsonName: `🌐 Response for GET related-visitors '${subscription.name}' > 'badVisitorId'`,
         validator: visitorError400Validator,
         schemaName,
       });
@@ -570,7 +571,7 @@ async function validateErrorVisitor404Response(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for DELETE visitor '${subscription.name}' > '${nonExistentVisitorId}'`,
+        jsonName: `🌐 Response for DELETE visitor '${subscription.name}' > '${nonExistentVisitorId}'`,
         validator: visitorError404Validator,
         schemaName,
       });
@@ -582,7 +583,7 @@ async function validateErrorVisitor404Response(testSubscriptions: TestSubscripti
     } catch (error) {
       validateJson({
         json: (error as RequestError).responseBody,
-        jsonName: `🌐 Live Server API Response for GET related-visitors '${subscription.name}' > '${nonExistentVisitor}'`,
+        jsonName: `🌐 Response for GET related-visitors '${subscription.name}' > '${nonExistentVisitor}'`,
         validator: visitorError404Validator,
         schemaName,
       });
@@ -619,7 +620,7 @@ async function validateRelatedVisitorsResponseSchema(testSubscriptions: TestSubs
     const relatedVisitorsResponse = await client.getRelatedVisitors({ visitor_id: subscription.visitorId });
     validateJson({
       json: relatedVisitorsResponse,
-      jsonName: `🌐 Live Server API Response for GET related-visitors '${subscription.name}' > '${subscription.visitorId}'`,
+      jsonName: `🌐 Response for GET related-visitors '${subscription.name}' > '${subscription.visitorId}'`,
       validator: relatedVisitorsResponseValidator,
       schemaName,
     });
@@ -769,6 +770,71 @@ async function validateSearchEventsResponseSchema(testSubscriptions: TestSubscri
   }
 }
 
+async function validateSearchEventsError400Schema(testSubscriptions: TestSubscription[]) {
+  const schemaName = 'ErrorResponse';
+  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
+  const searchEventsError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
+  const searchEventsError400Validator = ajv.compile(searchEventsError400Schema);
+
+  // Validate against example file
+  [
+    './schemas/paths/examples/errors/400_limit_invalid.json',
+    './schemas/paths/examples/errors/400_ip_address_invalid.json',
+    './schemas/paths/examples/errors/400_bot_type_invalid.json',
+    './schemas/paths/examples/errors/400_reverse_invalid.json',
+    './schemas/paths/examples/errors/400_start_time_invalid.json',
+    './schemas/paths/examples/errors/400_end_time_invalid.json',
+    './schemas/paths/examples/errors/400_visitor_id_invalid.json',
+    './schemas/paths/examples/errors/400_linked_id_invalid.json',
+    './schemas/paths/examples/errors/400_pagination_key_invalid.json',
+  ].forEach((examplePath) =>
+    validateJson({
+      json: JSON.parse(fs.readFileSync(examplePath).toString()),
+      jsonName: examplePath,
+      validator: searchEventsError400Validator,
+      schemaName,
+    })
+  );
+
+  // Validate against live Server API responses
+  for (const subscription of testSubscriptions) {
+    const client = new FingerprintJsServerApiClient({
+      apiKey: subscription.serverApiKey,
+      region: REGION_MAP[subscription.region || 'us'],
+    });
+
+    const filters = [
+      { limit: 'invalid limit' },
+      { limit: 1, ip_address: 'not an ip address' },
+      { limit: 1, end: 'not a timestamp' },
+      { limit: 1, start: 'not a timestamp' },
+      { limit: 1, linked_id: 'C'.repeat(257) },
+      { limit: 1, visitor_id: 'not a visitor id' },
+      { limit: 1, reverse: 'not a boolean' },
+      { limit: 1, suspect: 'not a boolean' },
+      { limit: 1, pagination_key: false },
+      subscription.botDetectionEnabled && { limit: 1, bot: 'invalid bot value' },
+    ];
+
+    for (const filter of filters.filter(Boolean)) {
+      try {
+        // @ts-expect-error
+        const searchEventsResponse = await client.searchEvents(filter);
+        fail(
+          `❌ Request for search-events with filter '${JSON.stringify(filter)}' should have failed, but returned ${JSON.stringify(searchEventsResponse, null, 2)} in ${subscription.name}`
+        );
+      } catch (error) {
+        validateJson({
+          json: (error as RequestError).responseBody,
+          jsonName: `🌐 Live Server API Response for GET search-events with filter '${JSON.stringify(filter)}' in ${subscription.name}`,
+          validator: searchEventsError400Validator,
+          schemaName,
+        });
+      }
+    }
+  }
+}
+
 /**
  * Main function
  */
@@ -805,6 +871,8 @@ async function validateSearchEventsResponseSchema(testSubscriptions: TestSubscri
 
   await validateUpdateEventError400Schema(testSubscriptions);
   await validateUpdateEventError409Schema(testSubscriptions.slice(1, 2));
+
+  await validateSearchEventsError400Schema(testSubscriptions);
 
   if (exitCode === 0) {
     console.log('\n ✅✅✅ All schemas are valid');

--- a/bin/validateSchema.ts
+++ b/bin/validateSchema.ts
@@ -84,28 +84,19 @@ const REGION_MAP = {
   ap: Region.AP,
 } as const;
 
-function getCurrentFunctionName() {
-  try {
-    throw new Error();
-  } catch (e) {
-    // Parse the stack trace to get the function name
-    const stackLines = e.stack.split('\n');
-    // The calling function is typically at index 2 (after Error and getCurrentFunctionName)
-    const callerLine = stackLines[2];
-    // Extract the function name using regex
-    const match = callerLine.match(/at\s+(.*)\s+\(/);
-    return match ? `${match[1]}()` : 'anonymous';
-  }
-}
+const createValidator = (schemaName: string, functionName: string) => {
+  console.log(`\n⚡ ${functionName}() — validating ${schemaName} schema: \n`);
+  const jsonSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
+  const validator = ajv.compile(jsonSchema);
+  return validator;
+};
 
 /**
  * Validate EventResponse schema
  */
 async function validateEventResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'EventsGetResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const eventResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const eventValidator = ajv.compile(eventResponseSchema);
+  const eventValidator = createValidator(schemaName, 'validateEventResponseSchema');
 
   // Validate against example files
   [
@@ -150,9 +141,7 @@ async function validateEventResponseSchema(testSubscriptions: TestSubscription[]
  */
 export async function validateVisitsResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'VisitorsGetResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}:Validating ${schemaName} schema: \n`);
-  const visitsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitsResponseValidator = ajv.compile(visitsResponseSchema);
+  const visitsResponseValidator = createValidator(schemaName, 'validateVisitsResponseSchema');
 
   // Validate against example files
   [
@@ -194,9 +183,7 @@ export async function validateVisitsResponseSchema(testSubscriptions: TestSubscr
  */
 async function validateWebhookSchema() {
   const schemaName = 'Webhook';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const webhookSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const webhookValidator = ajv.compile(webhookSchema);
+  const webhookValidator = createValidator(schemaName, 'validateWebhookSchema');
 
   // Validate against example file
   ['./schemas/paths/examples/webhook.json'].forEach((examplePath) =>
@@ -214,9 +201,7 @@ async function validateWebhookSchema() {
  */
 async function validateCommonError403Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const commonError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const commonError403Validator = ajv.compile(commonError403Schema);
+  const commonError403Validator = createValidator(schemaName, 'validateCommonError403Schema');
 
   // Validate against example file
   [
@@ -310,9 +295,7 @@ async function validateCommonError403Schema(testSubscriptions: TestSubscription[
  */
 async function validateEventError404Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const eventError404Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const eventError404Validator = ajv.compile(eventError404Schema);
+  const eventError404Validator = createValidator(schemaName, 'validateEventError404Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/errors/404_request_not_found.json'].forEach((examplePath) =>
@@ -364,9 +347,7 @@ async function validateEventError404Schema(testSubscriptions: TestSubscription[]
  */
 async function validateGetVisitsError400Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorPlainResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const visitsError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitsError400Validator = ajv.compile(visitsError400Schema);
+  const visitsError400Validator = createValidator(schemaName, 'validateGetVisitsError400Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/get_visitors_400_bad_request.json'].forEach((examplePath) =>
@@ -404,9 +385,7 @@ async function validateGetVisitsError400Schema(testSubscriptions: TestSubscripti
  */
 async function validateGetVisitsError403Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorPlainResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const visitsError403Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitsError403Validator = ajv.compile(visitsError403Schema);
+  const visitsError403Validator = createValidator(schemaName, 'validateGetVisitsError403Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/get_visitors_403_forbidden.json'].forEach((examplePath) =>
@@ -444,9 +423,7 @@ async function validateGetVisitsError403Schema(testSubscriptions: TestSubscripti
  */
 async function validateGetVisitsError429Schema() {
   const schemaName = 'ErrorPlainResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const visitsError429Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitsError429Validator = ajv.compile(visitsError429Schema);
+  const visitsError429Validator = createValidator(schemaName, 'validateGetVisitsError429Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/get_visitors_429_too_many_requests.json'].forEach((examplePath) =>
@@ -464,9 +441,7 @@ async function validateGetVisitsError429Schema() {
  */
 async function validateErrorCommon429Response() {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const errorCommon429ResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const errorCommon429ResponseValidator = ajv.compile(errorCommon429ResponseSchema);
+  const errorCommon429ResponseValidator = createValidator(schemaName, 'validateErrorCommon429Response');
 
   // Validate against example file
   ['./schemas/paths/examples/errors/429_too_many_requests.json'].forEach((examplePath) =>
@@ -484,9 +459,7 @@ async function validateErrorCommon429Response() {
  */
 async function validateErrorVisitor400Response(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const visitorError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitorError400Validator = ajv.compile(visitorError400Schema);
+  const visitorError400Validator = createValidator(schemaName, 'validateErrorVisitor400Response');
 
   // Validate against example file
   [
@@ -541,9 +514,7 @@ async function validateErrorVisitor400Response(testSubscriptions: TestSubscripti
  */
 async function validateErrorVisitor404Response(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const visitorError404Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const visitorError404Validator = ajv.compile(visitorError404Schema);
+  const visitorError404Validator = createValidator(schemaName, 'validateErrorVisitor404Response');
 
   // Validate against example file
   ['./schemas/paths/examples/errors/404_visitor_not_found.json'].forEach((examplePath) =>
@@ -593,9 +564,7 @@ async function validateErrorVisitor404Response(testSubscriptions: TestSubscripti
 
 async function validateRelatedVisitorsResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'RelatedVisitorsResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const relatedVisitorsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const relatedVisitorsResponseValidator = ajv.compile(relatedVisitorsResponseSchema);
+  const relatedVisitorsResponseValidator = createValidator(schemaName, 'validateRelatedVisitorsResponseSchema');
 
   // Validate against example file
   [
@@ -632,9 +601,7 @@ async function validateRelatedVisitorsResponseSchema(testSubscriptions: TestSubs
  */
 async function validateUpdateEventError400Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const updateEvent400ErrorSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const updateEvent400ErrorValidator = ajv.compile(updateEvent400ErrorSchema);
+  const updateEvent400ErrorValidator = createValidator(schemaName, 'validateUpdateEventError400Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/errors/400_request_body_invalid.json'].forEach((examplePath) =>
@@ -675,9 +642,7 @@ async function validateUpdateEventError400Schema(testSubscriptions: TestSubscrip
  */
 async function validateUpdateEventError409Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const updateEvent409ErrorSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const updateEvent409ErrorValidator = ajv.compile(updateEvent409ErrorSchema);
+  const updateEvent409ErrorValidator = createValidator(schemaName, 'validateUpdateEventError409Schema');
 
   // Validate against example file
   ['./schemas/paths/examples/errors/409_state_not_ready.json'].forEach((examplePath) =>
@@ -723,9 +688,7 @@ async function validateUpdateEventError409Schema(testSubscriptions: TestSubscrip
 
 async function validateSearchEventsResponseSchema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'SearchEventsResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const searchEventsResponseSchema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const searchEventsResponseValidator = ajv.compile(searchEventsResponseSchema);
+  const searchEventsResponseValidator = createValidator(schemaName, 'validateSearchEventsResponseSchema');
 
   // Validate against example file
   ['./schemas/paths/examples/get_event_search_200.json'].forEach((examplePath) =>
@@ -772,9 +735,7 @@ async function validateSearchEventsResponseSchema(testSubscriptions: TestSubscri
 
 async function validateSearchEventsError400Schema(testSubscriptions: TestSubscription[]) {
   const schemaName = 'ErrorResponse';
-  console.log(`\n⚡ ${getCurrentFunctionName()}: Validating ${schemaName} schema: \n`);
-  const searchEventsError400Schema = convertOpenApiToJsonSchema(OPEN_API_SCHEMA, `#/definitions/${schemaName}`);
-  const searchEventsError400Validator = ajv.compile(searchEventsError400Schema);
+  const searchEventsError400Validator = createValidator(schemaName, 'validateSearchEventsError400Schema');
 
   // Validate against example file
   [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fingerprintjs/changesets-changelog-format": "^0.2.0",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
     "@fingerprintjs/eslint-config-dx-team": "^0.1.0",
-    "@fingerprintjs/fingerprintjs-pro-server-api": "^4.1.2",
+    "@fingerprintjs/fingerprintjs-pro-server-api": "^6.3.0",
     "@fingerprintjs/prettier-config-dx-team": "^0.1.0",
     "@fingerprintjs/tsconfig-dx-team": "^0.0.2",
     "@quobix/vacuum": "^0.9.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@types/eslint@8.56.10)(prettier@3.2.5)(typescript@5.5.3)
       '@fingerprintjs/fingerprintjs-pro-server-api':
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^6.3.0
+        version: 6.3.0
       '@fingerprintjs/prettier-config-dx-team':
         specifier: ^0.1.0
         version: 0.1.0
@@ -59,13 +59,13 @@ importers:
         version: 2.1.1(ajv@8.16.0)
       clean-webpack-plugin:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 4.0.0(webpack@5.94.0)
       copy-webpack-plugin:
         specifier: ^12.0.2
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       css-loader:
         specifier: ^6.11.0
-        version: 6.11.0(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 6.11.0(webpack@5.94.0)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -77,7 +77,7 @@ importers:
         version: 11.0.0
       html-webpack-plugin:
         specifier: ^5.6.0
-        version: 5.6.0(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 5.6.0(webpack@5.94.0)
       human-id:
         specifier: ^4.1.1
         version: 4.1.1
@@ -95,13 +95,13 @@ importers:
         version: 1.45.1
       style-loader:
         specifier: ^3.3.4
-        version: 3.3.4(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 3.3.4(webpack@5.94.0)
       swagger-ui:
         specifier: ^5.17.14
         version: 5.17.14(ramda@0.30.1)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.5.3)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.5.3)(webpack@5.94.0)
       tsx:
         specifier: ^4.16.2
         version: 4.16.2
@@ -543,8 +543,8 @@ packages:
     peerDependencies:
       prettier: '>=3'
 
-  '@fingerprintjs/fingerprintjs-pro-server-api@4.1.2':
-    resolution: {integrity: sha512-rKdVmYo/z6Fqkt5DHp9r6NYVtm/HuriCzja7lFOffBW7sNEVJ5iFXwlFnZ92Hp5n2k2fqcNaAM5cw5I7dZ5mnw==}
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.3.0':
+    resolution: {integrity: sha512-Kig3A+sEBoTvOXqgj+MvND2prF6WId/bO/vCz4ZMUhW8s4FRRv5SUohcH+k5npdwTJy3t6qSZP7DUPYNM/PEsg==}
     engines: {node: '>=18.17.0'}
 
   '@fingerprintjs/prettier-config-dx-team@0.1.0':
@@ -4529,7 +4529,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fingerprintjs/fingerprintjs-pro-server-api@4.1.2': {}
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.3.0': {}
 
   '@fingerprintjs/prettier-config-dx-team@0.1.0':
     dependencies:
@@ -5483,17 +5483,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack-dev-server@5.0.4(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
@@ -5823,7 +5823,7 @@ snapshots:
     dependencies:
       source-map: 0.6.1
 
-  clean-webpack-plugin@4.0.0(webpack@5.94.0(webpack-cli@5.1.4)):
+  clean-webpack-plugin@4.0.0(webpack@5.94.0):
     dependencies:
       del: 4.1.1
       webpack: 5.94.0(webpack-cli@5.1.4)
@@ -5915,7 +5915,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  copy-webpack-plugin@12.0.2(webpack@5.94.0(webpack-cli@5.1.4)):
+  copy-webpack-plugin@12.0.2(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -5956,7 +5956,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.11.0(webpack@5.94.0(webpack-cli@5.1.4)):
+  css-loader@6.11.0(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.39)
       postcss: 8.4.39
@@ -6645,7 +6645,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.31.1
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -8239,7 +8239,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.94.0(webpack-cli@5.1.4)):
+  style-loader@3.3.4(webpack@5.94.0):
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
 
@@ -8357,7 +8357,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -8429,7 +8429,7 @@ snapshots:
     dependencies:
       typescript: 5.5.3
 
-  ts-loader@9.5.1(typescript@5.5.3)(webpack@5.94.0(webpack-cli@5.1.4)):
+  ts-loader@9.5.1(typescript@5.5.3)(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.0
@@ -8544,9 +8544,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0))(webpack-dev-server@5.0.4(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -8560,7 +8560,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.94.0)
 
-  webpack-dev-middleware@7.2.1(webpack@5.94.0(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.2.1(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.3
@@ -8601,7 +8601,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.94.0(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.2.1(webpack@5.94.0)
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
@@ -8642,7 +8642,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
* Updated Node SDK
* Now using Node SDK for all requests instead of fetch + hacks
* Added checks for the Search Events endpoint and schemas
* Small fixes, style unifications

There is some refactoring potential here but I would prefer to do it as a separate PR, open to discussion.