### PR TITLE
PLAT: add environmentId to webhook

### DIFF
--- a/.changeset/thick-clouds-ring.md
+++ b/.changeset/thick-clouds-ring.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-openapi": patch
+---
+
+PLAT: add environmentId to webhook

--- a/.changeset/thick-clouds-ring.md
+++ b/.changeset/thick-clouds-ring.md
@@ -2,4 +2,4 @@
 "fingerprint-pro-server-api-openapi": patch
 ---
 
-Add `environmentId` property to webhook
+**webhook**: Add `environmentId` property

--- a/.changeset/thick-clouds-ring.md
+++ b/.changeset/thick-clouds-ring.md
@@ -2,4 +2,4 @@
 "fingerprint-pro-server-api-openapi": patch
 ---
 
-PLAT: add environmentId to webhook
+Add `environmentId` property to webhook

--- a/schemas/components/schemas/Webhook.yaml
+++ b/schemas/components/schemas/Webhook.yaml
@@ -15,6 +15,9 @@ properties:
   ip:
     type: string
     description: IP address of the requesting browser or bot.
+  environmentId:
+    type: string
+    description: Environment ID of the event.
   tag:
     $ref: Tag.yaml
   time:


### PR DESCRIPTION
Between the time Nikolai did his generation of OpenAPI based poster code and when I rebased / deployed it, `environmentId` was added to the webhook schema (without updating OpenAPI). Deploying the OpenAPI based poster code resulted in a regression where environmentId is now missing from webhooks.

This change adds it to the schema, so that we can then generate the appropriate type and populate it in poster-worker.