### PR TITLE
INTER-1216: Fix incorrect enum value for vpn_confidence

### DIFF
--- a/.changeset/gold-flies-doubt.md
+++ b/.changeset/gold-flies-doubt.md
@@ -2,4 +2,4 @@
 'fingerprint-pro-server-api-openapi': patch
 ---
 
-**events-search**: Fixed vpn_confidence enum value
+**events-search**: Fixed `vpn_confidence` query parameter enum value formatting (`high,` -> `high`)

--- a/.changeset/gold-flies-doubt.md
+++ b/.changeset/gold-flies-doubt.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': patch
+---
+
+**events-search**: Fixed vpn_confidence enum value

--- a/schemas/paths/event-search.yaml
+++ b/schemas/paths/event-search.yaml
@@ -185,7 +185,7 @@ get:
       schema:
         type: string
         enum:
-          - high,
+          - high
           - medium
           - low
       description: |


### PR DESCRIPTION
This PR fixes a typo in the `vpn_confidence` enum definition in the `event-search.yaml` file.

## 🤔  Why?

The value `"high,"` (had an extra comma at the end), which was causing issues in the OpenAPI schema and related Server SDKs.