### PR TITLE
Rename "Fingerprint Pro Server API" to "Fingerprint Server API"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Fingerprint Pro Server API OpenAPI
+# Contributing to Fingerprint Server API OpenAPI
 
-The repository contains OpenAPI definition files for various [Fingerprint Pro Server-side APIs](https://dev.fingerprint.com/reference).
+The repository contains OpenAPI definition files for various [Fingerprint Server-side APIs](https://dev.fingerprint.com/reference).
 
 ## Schemas
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://discord.gg/39EpE2neBg"><img src="https://img.shields.io/discord/852099967190433792?style=logo&label=Discord&logo=Discord&logoColor=white" alt="Discord server"></a>
 </p>
 
-# Fingerprint Pro Server API OpenAPI Schema
+# Fingerprint Server API OpenAPI Schema
 
 [Fingerprint](https://fingerprint.com) is a device intelligence platform offering industry-leading accuracy. Fingerprint [Server API](https://dev.fingerprint.com/reference/pro-server-api) allows you to search, update, and delete identification events in a server environment.
 

--- a/schemas/fingerprint-server-api-for-sdks.yaml
+++ b/schemas/fingerprint-server-api-for-sdks.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Fingerprint Server API
   description: |
-    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
+    Fingerprint Server API allows you to search, update, and delete identification events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
   version: '3'
   contact:

--- a/schemas/fingerprint-server-api-for-sdks.yaml
+++ b/schemas/fingerprint-server-api-for-sdks.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Fingerprint Pro Server API
+  title: Fingerprint Server API
   description: |
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
   version: '3'
   contact:

--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Fingerprint Server API
   description: |
-    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
+    Fingerprint Server API allows you to search, update, and delete identification events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
   version: '3'
   contact:

--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Fingerprint Pro Server API
+  title: Fingerprint Server API
   description: |
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios.
     Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.
   version: '3'
   contact:


### PR DESCRIPTION
Updated documentation and code comments to reflect the new naming convention. Replaced all instances of `Fingerprint Pro Server API` with `Fingerprint Server API`.

Related-Task: INTER-1240