### PR TITLE
Add @erayaydin to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-* @TheUnderScorer @JuroUhlar @ilfa
+* @TheUnderScorer @JuroUhlar @ilfa @erayaydin


### PR DESCRIPTION
This PR adds @erayaydin to the `CODEOWNERS` file to include them in future review requests directly.