### PR TITLE
chore: fix yaml issues in fingerprint-server-api-readme-explorer.yaml

### DIFF
--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -274,7 +274,7 @@ paths:
                         data:
                           result: false
                           confidence: "high"
-                          mlScore: 0.3231,
+                          mlScore: 0.3231
                           anomalyScore: 0.1955
                           antiDetectBrowser: false
                       clonedApp:

--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -273,7 +273,7 @@ paths:
                       tampering:
                         data:
                           result: false
-                          confidence: "high",
+                          confidence: "high"
                           mlScore: 0.3231,
                           anomalyScore: 0.1955
                           antiDetectBrowser: false
@@ -1798,7 +1798,7 @@ paths:
                           tampering:
                             data:
                               result: false
-                              confidence: "high",
+                              confidence: "high"
                               mlScore: 0.3231,
                               anomalyScore: 0.1955
                               antiDetectBrowser: false


### PR DESCRIPTION
- Remove some stray commas in the readme-explorer schema