### PR TITLE
chore: repurpose v4 normalized schema

### DIFF
--- a/utils/mocks/schemaWithOneOfQueryParameter.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameter.yaml
@@ -1,0 +1,18 @@
+openapi: 3.1.1
+info:
+  title: test
+  version: '1.0'
+paths:
+  /v4/events:
+    get:
+      operationId: getEvents
+      parameters:
+        - name: timestamp
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: integer
+                format: int64
+              - type: string
+                format: date-time

--- a/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.1
+info:
+  title: test
+  version: '1.0'
+paths:
+  /v4/events:
+    get:
+      operationId: getEvents
+      parameters:
+        - name: timestamp
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: timestamp_date_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time

--- a/utils/transformers/expandOneOfQueryParametersTransformer.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.js
@@ -1,0 +1,55 @@
+/**
+ * Derives a parameter name suffix from a schema option's format or type.
+ * @param {Record<string, unknown>} schema
+ * @returns {string}
+ */
+function getSuffix(schema) {
+  const format = typeof schema.format === 'string' ? schema.format : null;
+  const type = typeof schema.type === 'string' ? schema.type : null;
+  const raw = format ?? type ?? 'unknown';
+  return raw.replace(/-/g, '_');
+}
+
+/**
+ * Expands query parameters whose schema uses `oneOf` into one parameter per option.
+ * The first option retains the original parameter name; subsequent options are named
+ * `<originalName>_<suffix>` where the suffix is derived from the option's format or type.
+ * @param {Record<string, unknown>} apiDefinition
+ */
+export function expandOneOfQueryParametersTransformer(apiDefinition) {
+  const paths = apiDefinition?.paths;
+  if (!paths || typeof paths !== 'object') {
+    return;
+  }
+
+  for (const pathItem of Object.values(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') {
+      continue;
+    }
+
+    for (const operation of Object.values(pathItem)) {
+      if (!operation || typeof operation !== 'object' || !Array.isArray(operation.parameters)) {
+        continue;
+      }
+
+      const expanded = [];
+      for (const param of operation.parameters) {
+        if (param.in !== 'query' || !param.schema || !Array.isArray(param.schema.oneOf)) {
+          expanded.push(param);
+          continue;
+        }
+
+        const { oneOf, ...restSchema } = param.schema;
+        const { schema, ...restParam } = param;
+        void schema; // schema is unused
+
+        oneOf.forEach((option, index) => {
+          const name = index === 0 ? param.name : `${param.name}_${getSuffix(option)}`;
+          expanded.push({ ...restParam, name, schema: { ...restSchema, ...option } });
+        });
+      }
+
+      operation.parameters = expanded;
+    }
+  }
+}

--- a/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParametersTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const schemaWithOneOfQueryParameter = fs.readFileSync('./utils/mocks/schemaWithOneOfQueryParameter.yaml');
+const schemaWithOneOfQueryParameterTransformed = fs.readFileSync(
+  './utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml'
+);
+
+const applyTransformer = (yaml) => transformSchema(yaml, [expandOneOfQueryParametersTransformer]);
+
+describe('Test expandOneOfQueryParametersTransformer', () => {
+  it('does not modify schema without oneOf query parameters', () => {
+    const result = applyTransformer(simpleYaml);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('expands oneOf query parameters into separate parameters', () => {
+    const result = applyTransformer(schemaWithOneOfQueryParameter);
+    expect(result.toString()).toEqual(schemaWithOneOfQueryParameterTransformed.toString());
+  });
+});

--- a/utils/transformers/parseYaml.js
+++ b/utils/transformers/parseYaml.js
@@ -8,3 +8,13 @@ import yaml from 'js-yaml';
 export function parseYaml(content) {
   return /** @type {Record<string, any>} */ (yaml.load(content.toString()));
 }
+
+/**
+ * Serializes an object into a YAML document.
+ *
+ * @param {unknown} input
+ * @returns {string}
+ */
+export function toYaml(input) {
+  return yaml.dump(input);
+}

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
-import { resolveAllOfRecursivelyTransformer, resolveAllOfTransformer } from './resolveAllOfTransformer.js';
-import { resolveOneOfTransformer, resolveAnyOfTransformer } from './resolveOneOfTransformer.js';
+import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
+import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParametersTransformer.js';
 import { removeWebhookTransformer } from './removeWebhookTransformer.js';
 import { replaceTagsTransformer } from './replaceTagsTransformer.js';
 import { removeBigExamplesTransformer } from './removeBigExamplesTransformer.js';
@@ -51,11 +51,7 @@ export const v4SchemaForSdksTransformers = [
 
 export const v4SchemaForSdksNormalizedTransformers = [
   ...v4SchemaForSdksCommonTransformers,
-  resolveAllOfRecursivelyTransformer,
-  resolveOneOfTransformer,
-  resolveAnyOfTransformer,
-  // do this at the end of the pipeline again to make sure previous transformers didn't introduce it again
-  removeFieldTransformer('additionalProperties', false),
+  expandOneOfQueryParametersTransformer,
   // This transformer should run last to ensure all unused schemas are found
   removeUnusedSchemasTransformer,
 ];

--- a/utils/transformers/transformSchema.spec.js
+++ b/utils/transformers/transformSchema.spec.js
@@ -6,7 +6,7 @@ import {
   v4SchemaForSdksTransformers,
   v4SchemaForSdksNormalizedTransformers,
 } from './transformSchema.js';
-import { parseYaml } from './parseYaml.js';
+import { parseYaml, toYaml } from './parseYaml.js';
 
 const v4Schema = fs.readFileSync('./schemas/fingerprint-server-api-v4.yaml');
 
@@ -79,22 +79,15 @@ describe('Test transformSchema pipelines for v4', () => {
     });
   });
 
-  it('v4 normalized sdk schema removes examples, additionalProperties: false, composition operators and path-operation inline enums', () => {
+  it('v4 normalized sdk schema removes examples, additionalProperties: false, oneOf query parameters', () => {
     const result = transformSchema(v4Schema, v4SchemaForSdksNormalizedTransformers);
 
     expect(hasYamlKey(result, 'examples')).toBe(false);
     expect(hasYamlKey(result, 'additionalProperties', false)).toBe(false);
-    expect(hasYamlKey(result, 'oneOf')).toBe(false);
-    expect(hasYamlKey(result, 'anyOf')).toBe(false);
 
     const parsed = parseYaml(result);
-    const parameters = parsed.paths['/events'].get.parameters;
-    expectPathOperationInlineEnumsExtractedToComponents(parameters, parsed.components.schemas);
+    const pathsYaml = toYaml(parsed.paths);
 
-    expect(parsed.components.schemas.EventRuleAction.properties.type).toEqual({
-      type: 'string',
-      description: 'Describes the action to take with the request.',
-      enum: ['allow', 'block'],
-    });
+    expect(hasYamlKey(pathsYaml, 'oneOf')).toBe(false);
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ export default {
           from: 'schemas/fingerprint-server-api-v4.yaml',
           // normalized schema used by SDKs in weakly typed languages
           // examples are removed
-          // `oneOf` operators and similar are resolved
+          // `oneOf` query parameters are split into two or more parameters
           // additionalProperties: false are removed for backward compatibility
           to: 'schemas/fingerprint-server-api-v4-normalized.yaml',
           transform: (content) => transformSchema(content, v4SchemaForSdksNormalizedTransformers),


### PR DESCRIPTION
- Update the transformers for the v4 normalized schema to use the new `expandOneOfQueryParametersTransformer` to split query parameters that use `oneOf` into two or more parameters