### PR TITLE
CI: Increase test workflow timeout to 6 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint, build and test
     runs-on: ubuntu-latest
     environment: test
-    timeout-minutes: 3
+    timeout-minutes: 6
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Increases `test.yml` workflow timeout to `6` minutes.