### PR TITLE
ci: increase test workflow timeout to 30 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint, build and test
     runs-on: ubuntu-latest
     environment: test
-    timeout-minutes: 6
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,4 +16,4 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/test-and-build
         with:
-          testSubscriptions: '${{ secrets.TEST_SUBSCRIPTIONS }}'
+          testSubscriptions: "${{ secrets.TEST_SUBSCRIPTIONS }}"


### PR DESCRIPTION
## Summary
- Bump test workflow `timeout-minutes` from 6 to 30 to avoid premature cancellation
- Minor quote style normalization in `testSubscriptions`

## Test plan
- [ ] CI runs to completion under new timeout