### PR TITLE
chore: temporarily remove some elements from server SDK schema

### DIFF
--- a/utils/mocks/schemaWithUnusedSchemasInlined.yaml
+++ b/utils/mocks/schemaWithUnusedSchemasInlined.yaml
@@ -1,0 +1,69 @@
+openapi: 3.1.1
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+components:
+  schemas:
+    Response:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+        - type: object
+          properties:
+            result:
+              oneOf:
+                - $ref: '#/components/schemas/OptionA'
+                - $ref: '#/components/schemas/OptionB'
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Item'
+    BaseResponse:
+      type: object
+      properties:
+        id:
+          type: string
+    OptionA:
+      type: object
+      properties:
+        typeA:
+          type: string
+    OptionB:
+      type: object
+      properties:
+        typeB:
+          type: string
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+    Node:
+      type: object
+      properties:
+        value:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+    UnusedSchemaA:
+      type: object
+      properties:
+        unused:
+          type: string
+    UnusedSchemaB:
+      type: object
+      properties:
+        alsoUnused:
+          type: string
+    UnusedSchemaC:
+      type: string

--- a/utils/transformers/inlineReferencedPropertiesTransformer.js
+++ b/utils/transformers/inlineReferencedPropertiesTransformer.js
@@ -1,0 +1,26 @@
+import { walkJson } from '../walkJson.js';
+import { resolveComponent } from '../resolveComponent.js';
+
+function inlineProperties(properties, schemas) {
+  Object.keys(properties).forEach((propName) => {
+    const prop = properties[propName];
+    if (prop?.$ref) {
+      const resolved = resolveComponent(prop.$ref, schemas);
+      if (resolved) {
+        properties[propName] = structuredClone(resolved);
+      }
+    }
+  });
+}
+
+export function inlineReferencedPropertiesTransformer(parentName) {
+  return function (apiDefinition) {
+    const schemas = apiDefinition?.components?.schemas;
+    if (!schemas) return;
+
+    const target = schemas[parentName];
+    if (target?.properties) {
+      inlineProperties(target.properties, schemas);
+    }
+  };
+}

--- a/utils/transformers/inlineReferencedPropertiesTransformer.js
+++ b/utils/transformers/inlineReferencedPropertiesTransformer.js
@@ -1,4 +1,3 @@
-import { walkJson } from '../walkJson.js';
 import { resolveComponent } from '../resolveComponent.js';
 
 function inlineProperties(properties, schemas) {

--- a/utils/transformers/inlineReferencedPropertiesTransformer.spec.js
+++ b/utils/transformers/inlineReferencedPropertiesTransformer.spec.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { inlineReferencedPropertiesTransformer } from './inlineReferencedPropertiesTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const schemaWithUnusedSchemas = fs.readFileSync('./utils/mocks/schemaWithUnusedSchemas.yaml');
+const schemaWithUnusedSchemasInlined = fs.readFileSync('./utils/mocks/schemaWithUnusedSchemasInlined.yaml');
+
+const applyTransformer = (yaml, parentName) =>
+  transformSchema(yaml, [inlineReferencedPropertiesTransformer(parentName)]);
+
+describe('Test inlineReferencedPropertiesTransformer', () => {
+  it("doesn't do anything when no properties use $ref", () => {
+    const result = applyTransformer(simpleYaml);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('inlines $ref properties only within the named schema', () => {
+    const result = applyTransformer(schemaWithUnusedSchemas, 'UnusedSchemaB');
+    expect(result.toString()).toEqual(schemaWithUnusedSchemasInlined.toString());
+  });
+});

--- a/utils/transformers/removeFieldByPathTransformer.js
+++ b/utils/transformers/removeFieldByPathTransformer.js
@@ -4,6 +4,6 @@ export function removeFieldByPathTransformer(pathSegments) {
   return function (apiDefinition) {
     walkJsonByPath(apiDefinition, pathSegments, (obj, key) => {
       delete obj[key];
-    })
+    });
   };
 }

--- a/utils/transformers/removeFieldByPathTransformer.js
+++ b/utils/transformers/removeFieldByPathTransformer.js
@@ -1,0 +1,9 @@
+import { walkJsonByPath } from '../walkJson.js';
+
+export function removeFieldByPathTransformer(pathSegments) {
+  return function (apiDefinition) {
+    walkJsonByPath(apiDefinition, pathSegments, (obj, key) => {
+      delete obj[key];
+    })
+  };
+}

--- a/utils/transformers/removeFieldByPathTransformer.spec.js
+++ b/utils/transformers/removeFieldByPathTransformer.spec.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { removeFieldByPathTransformer } from './removeFieldByPathTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const schemaWithXReadme = fs.readFileSync('./utils/mocks/schemaWithXReadme.yaml');
+const schemaWithXReadmeCleaned = fs.readFileSync('./utils/mocks/schemaWithXReadmeCleaned.yaml');
+describe('Test removeFieldByPathTransformer', () => {
+  it("doesn't do anything when path doesn't exist", () => {
+    const result = transformSchema(simpleYaml, [
+      removeFieldByPathTransformer(['components', 'schemas', 'Response', 'nonexistent']),
+    ]);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('removes a field at an exact nested path', () => {
+    const result = transformSchema(schemaWithXReadme, [
+      removeFieldByPathTransformer(['paths', '/visitors/{visitor_id}', 'get', 'x-readme']),
+    ]);
+    expect(result.toString()).toEqual(schemaWithXReadmeCleaned.toString());
+  });
+
+  it('removes a field from array elements using a wildcard segment', () => {
+    const result = transformSchema(simpleYaml, [
+      removeFieldByPathTransformer(['servers', '*', 'description']),
+    ]);
+    expect(result).not.toContain('Global');
+    expect(result).toContain('https://api.fpjs.io');
+  });
+});

--- a/utils/transformers/removeFieldByPathTransformer.spec.js
+++ b/utils/transformers/removeFieldByPathTransformer.spec.js
@@ -21,9 +21,7 @@ describe('Test removeFieldByPathTransformer', () => {
   });
 
   it('removes a field from array elements using a wildcard segment', () => {
-    const result = transformSchema(simpleYaml, [
-      removeFieldByPathTransformer(['servers', '*', 'description']),
-    ]);
+    const result = transformSchema(simpleYaml, [removeFieldByPathTransformer(['servers', '*', 'description'])]);
     expect(result).not.toContain('Global');
     expect(result).toContain('https://api.fpjs.io');
   });

--- a/utils/transformers/removeObjectByPathTransformer.js
+++ b/utils/transformers/removeObjectByPathTransformer.js
@@ -1,0 +1,15 @@
+import { walkJsonByPath } from '../walkJson.js';
+
+export function removeObjectByPathTransformer(pathSegments, matcher) {
+  return function (apiDefinition) {
+    walkJsonByPath(apiDefinition, pathSegments, (obj, key) => {
+      if (matcher(obj[key])) {
+        if (Array.isArray(obj)) {
+          obj.splice(key, 1);
+        } else {
+          delete obj[key];
+        }
+      }
+    });
+  };
+}

--- a/utils/transformers/removeObjectByPathTransformer.spec.js
+++ b/utils/transformers/removeObjectByPathTransformer.spec.js
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { removeObjectByPathTransformer } from './removeObjectByPathTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const schemaWithXReadme = fs.readFileSync('./utils/mocks/schemaWithXReadme.yaml');
+const schemaWithXReadmeCleaned = fs.readFileSync('./utils/mocks/schemaWithXReadmeCleaned.yaml');
+
+describe('Test removeObjectByPathTransformer', () => {
+  it("doesn't do anything when path doesn't exist", () => {
+    const result = transformSchema(simpleYaml, [
+      removeObjectByPathTransformer(['components', 'schemas', 'Response', 'nonexistent'], () => true),
+    ]);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it("doesn't do anything when matcher returns false", () => {
+    const result = transformSchema(simpleYaml, [
+      removeObjectByPathTransformer(['components', 'schemas', 'Response', 'title'], () => false),
+    ]);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('removes an object key when matcher returns true', () => {
+    const result = transformSchema(schemaWithXReadme, [
+      removeObjectByPathTransformer(
+        ['paths', '/visitors/{visitor_id}', 'get', 'x-readme'],
+        (val) => 'code-samples' in val
+      ),
+    ]);
+    expect(result.toString()).toEqual(schemaWithXReadmeCleaned.toString());
+  });
+
+  it('splices an array element when matcher returns true', () => {
+    const result = transformSchema(simpleYaml, [
+      removeObjectByPathTransformer(['servers', '*'], (val) => val.description === 'Global'),
+    ]);
+    expect(result).not.toContain('Global');
+    expect(result).not.toContain('https://api.fpjs.io');
+  });
+});

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -14,6 +14,9 @@ import { extractPathOperationInlineEnumsTransformer } from './extractPathOperati
 import { parseYaml } from './parseYaml.js';
 import { removeUnusedSchemasTransformer } from './removeUnusedSchemasTransformer.js';
 import { liftOneOfSharedPropertiesTransformer } from './liftOneOfSharedPropertiesTransformer.js';
+import { removeFieldByPathTransformer } from './removeFieldByPathTransformer.js';
+import { removeObjectByPathTransformer } from './removeObjectByPathTransformer.js';
+import { inlineReferencedPropertiesTransformer } from './inlineReferencedPropertiesTransformer.js';
 
 export const commonTransformers = [
   resolveRefTransformer({ schemaPath: './schemas' }),
@@ -45,6 +48,19 @@ export const v4SchemaForSdksCommonTransformers = [
 
 export const v4SchemaForSdksTransformers = [
   ...v4SchemaForSdksCommonTransformers,
+
+  // The following transformers temporarily remove some fields to unblock server SDK releases
+  // Remove the use of oneOf for start and end query parameters
+  expandOneOfQueryParametersTransformer,
+  removeObjectByPathTransformer(
+    ['paths', '/events', 'get', 'parameters', '*'],
+    (parameter) => parameter.name === 'start_date_time' || parameter.name === 'end_date_time'
+  ),
+  // Inline enums previously extracted from BotInfo to avoid breaking changes in the SDKs
+  inlineReferencedPropertiesTransformer('BotInfo'),
+  // Remove the added enum attribute for BotInfo.category
+  removeFieldByPathTransformer(['components', 'schemas', 'BotInfo', 'properties', 'category', 'enum']),
+
   // This transformer should run last to ensure all unused schemas are found
   removeUnusedSchemasTransformer,
 ];

--- a/utils/walkJson.js
+++ b/utils/walkJson.js
@@ -34,7 +34,7 @@ export function walkJsonByPrefix(json, prefix, callback) {
  * the specified path.
  *
  * @param {Object} json
- * @param {string[]} pathSegments 
+ * @param {string[]} pathSegments
  * @param {Function} callback  - receives (obj, key) that matches the specified path
  */
 export function walkJsonByPath(json, pathSegments, callback) {
@@ -47,7 +47,7 @@ export function walkJsonByPath(json, pathSegments, callback) {
           // The target of the path has been found
           callback(json, iteratorKey);
         } else if (typeof value === 'object') {
-          walkJsonByPath(value, remainingSegments, callback)
+          walkJsonByPath(value, remainingSegments, callback);
         }
       }
     }

--- a/utils/walkJson.js
+++ b/utils/walkJson.js
@@ -28,3 +28,28 @@ export function walkJsonByPrefix(json, prefix, callback) {
     }
   });
 }
+
+/**
+ * Walk a JSON object to find the object containing the property identified by
+ * the specified path.
+ *
+ * @param {Object} json
+ * @param {string[]} pathSegments 
+ * @param {Function} callback  - receives (obj, key) that matches the specified path
+ */
+export function walkJsonByPath(json, pathSegments, callback) {
+  Object.keys(json).forEach((iteratorKey) => {
+    const [currentSegment, ...remainingSegments] = pathSegments;
+    if (currentSegment && (iteratorKey === currentSegment || currentSegment === '*')) {
+      const value = json[iteratorKey];
+      if (value) {
+        if (remainingSegments.length === 0) {
+          // The target of the path has been found
+          callback(json, iteratorKey);
+        } else if (typeof value === 'object') {
+          walkJsonByPath(value, remainingSegments, callback)
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
To unblock server SDK releases, this PR temporarily transforms the fingerprint-server-api-v4.yaml schema to avoid changes that would result in breaking changes in some of the SDKs:

- Add `removeFieldbyPathTransformer` and tests
- Add `removeObjectByPathTransformer` and tests
- Add `inlineReferencedPropertiesTransformer` and tests
- Use new transformers to remove the `oneOf` construct for the `start` and `end` query parameters
- Use new transformers to inline enums extracted from `BotInfo`
- Use new transformers to remove the `enum` attribute on the `BotInfoCategory` model

The [diff comment](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/pull/362#issuecomment-4382240797) is expected to show that for fingerprint-server-api-v4.yaml, the `BotInfo` is unchanged beyond a description update and the `start` and `end` query parameters are back to just accepting integers. This is a safe change to make for `fingerperint-server-api-v4.yaml` because the `start` and `end` updates haven't been released yet.