### PR TITLE
chore: update schema sync to use normalized schema for Go, Java, .NET

### DIFF
--- a/.changeset/cute-pumas-pull.md
+++ b/.changeset/cute-pumas-pull.md
@@ -2,4 +2,4 @@
 'fingerprint-pro-server-api-openapi': minor
 ---
 
-**events-search**: Add `start_date_time` and `end_date_time` RFC3339 timestamp filters
+**events-search**: Add `start_date_time` and `end_date_time` RFC3339 timestamp filters to the v4 normalized schema

--- a/.changeset/cute-pumas-pull.md
+++ b/.changeset/cute-pumas-pull.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': minor
+---
+
+**events-search**: Add `start_date_time` and `end_date_time` RFC3339 timestamp filters

--- a/.changeset/cute-pumas-pull.md
+++ b/.changeset/cute-pumas-pull.md
@@ -2,4 +2,4 @@
 'fingerprint-pro-server-api-openapi': minor
 ---
 
-**events-search**: Add `start_date_time` and `end_date_time` RFC3339 timestamp filters to the v4 normalized schema
+**events-search**: Add `start_date_time` and `end_date_time` RFC3339 timestamp filters

--- a/.github/workflows/sync-server-side-sdks-schema.yml
+++ b/.github/workflows/sync-server-side-sdks-schema.yml
@@ -70,6 +70,7 @@ jobs:
       language: golang
       language-version: 1.21
       generate-command: 'bash ./bin/openapi-codegen-docker.sh'
+      schema-source: fingerprint-server-api-v4-normalized.yaml
       schema-path: res/fingerprint-server-api-v4.yaml
       examples-path: test/mocks
       app-id: ${{ vars.RUNNER_APP_ID }}
@@ -89,6 +90,7 @@ jobs:
       language: dotnet
       language-version: '8.x'
       generate-command: 'bash ./generate.sh'
+      schema-source: fingerprint-server-api-v4-normalized.yaml
       schema-path: res/fingerprint-server-api.yaml
       examples-path: src/Fingerprint.ServerSdk.Test/mocks
       app-id: ${{ vars.RUNNER_APP_ID }}
@@ -129,6 +131,7 @@ jobs:
       language-version: '11'
       java-version: '11'
       generate-command: 'bash ./scripts/generate.sh'
+      schema-source: fingerprint-server-api-v4-normalized.yaml
       schema-path: res/fingerprint-server-api.yaml
       examples-path: sdk/src/test/resources/mocks
       app-id: ${{ vars.RUNNER_APP_ID }}

--- a/utils/mocks/schemaWithOneOfQueryParameter.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameter.yaml
@@ -10,6 +10,7 @@ paths:
         - name: timestamp
           in: query
           required: false
+          description: The original description
           schema:
             oneOf:
               - type: integer

--- a/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
@@ -10,12 +10,15 @@ paths:
         - name: timestamp
           in: query
           required: false
+          description: The updated description
           schema:
             type: integer
             format: int64
-        - name: timestamp_date_time
+          x-parameter-alias: timestamp_alias
+        - name: timestamp_alias
           in: query
           required: false
+          description: The description for the alias
           schema:
             type: string
             format: date-time

--- a/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml
@@ -19,3 +19,4 @@ paths:
           schema:
             type: string
             format: date-time
+          x-aliased-parameter-name: timestamp

--- a/utils/transformers/expandOneOfQueryParametersTransformer.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.js
@@ -1,3 +1,5 @@
+const VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME = 'x-aliased-parameter-name';
+
 /**
  * Derives a parameter name suffix from a schema option's format or type.
  * @param {Record<string, unknown>} schema
@@ -45,7 +47,14 @@ export function expandOneOfQueryParametersTransformer(apiDefinition) {
 
         oneOf.forEach((option, index) => {
           const name = index === 0 ? param.name : `${param.name}_${getSuffix(option)}`;
-          expanded.push({ ...restParam, name, schema: { ...restSchema, ...option } });
+          expanded.push({
+            ...restParam,
+            name,
+            schema: { ...restSchema, ...option },
+            // Add a vendor extension to the newly added parameters to indicate they are aliases the first
+            // parameter.
+            ...(index === 0 ? {} : { [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name }),
+          });
         });
       }
 

--- a/utils/transformers/expandOneOfQueryParametersTransformer.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.js
@@ -1,27 +1,18 @@
+const VENDOR_EXTENSION_PARAMETER_ALIAS_PROPERTY_NAME = 'x-parameter-alias';
 const VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME = 'x-aliased-parameter-name';
 
 /**
- * Derives a parameter name suffix from a schema option's format or type.
- * @param {Record<string, unknown>} schema
- * @returns {string}
- */
-function getSuffix(schema) {
-  const format = typeof schema.format === 'string' ? schema.format : null;
-  const type = typeof schema.type === 'string' ? schema.type : null;
-  const raw = format ?? type ?? 'unknown';
-  return raw.replace(/-/g, '_');
-}
-
-/**
- * Expands query parameters whose schema uses `oneOf` into one parameter per option.
- * The first option retains the original parameter name; subsequent options are named
- * `<originalName>_<suffix>` where the suffix is derived from the option's format or type.
+ * Finds specific query parameters that use the `oneOf` schema construct and replaces the parameter
+ * with two parameters. Only query parameters that use two schemas within the `oneOf` construct are
+ * supported.
  *
- * Use the `includeParams` parameter to only apply the transformer to parameters with a specific name
+ * The replacement parameters are defined by:
+ * - An override description for the first schema. This becomes the primary parameter
+ * - A name and description for the second schema. This becomes the alias of the primary parameter.
  *
- * @param {string[]} includeParams
+ * @param {Record<string, { overrideDescription: string; alias: { name: string; description:string; } }>} replacementParametersMap
  */
-export function expandOneOfQueryParametersTransformer(includeParams = []) {
+export function expandOneOfQueryParametersTransformer(replacementParametersMap) {
   return function (apiDefinition) {
     const paths = apiDefinition?.paths;
     if (!paths || typeof paths !== 'object') {
@@ -45,7 +36,8 @@ export function expandOneOfQueryParametersTransformer(includeParams = []) {
             continue;
           }
 
-          if (includeParams.length > 0 && !includeParams.includes(param.name)) {
+          const replacementParameter = replacementParametersMap[param.name];
+          if (!replacementParameter) {
             expanded.push(param);
             continue;
           }
@@ -54,16 +46,34 @@ export function expandOneOfQueryParametersTransformer(includeParams = []) {
           const { schema, ...restParam } = param;
           void schema; // schema is unused
 
-          oneOf.forEach((option, index) => {
-            const name = index === 0 ? param.name : `${param.name}_${getSuffix(option)}`;
-            expanded.push({
-              ...restParam,
-              name,
-              schema: { ...restSchema, ...option },
-              // Add a vendor extension to the newly added parameters to indicate they are aliases the first
-              // parameter.
-              ...(index === 0 ? {} : { [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name }),
-            });
+          if (oneOf.length !== 2) {
+            // Supporting anything other than exactly two oneOf schemas requires more complex handling
+            // in the server SDKs so throw an error to prevent that case from breaking code
+            // generation downstream
+            throw new Error('Unsupported use of oneOf construct in query parameter');
+          }
+
+          // The primary parameter
+          expanded.push({
+            ...restParam,
+            schema: {
+              ...restSchema,
+              ...oneOf[0],
+            },
+            description: replacementParameter.overrideDescription,
+            [VENDOR_EXTENSION_PARAMETER_ALIAS_PROPERTY_NAME]: replacementParameter.alias.name,
+          });
+
+          // The alias parameter
+          expanded.push({
+            ...restParam,
+            name: replacementParameter.alias.name,
+            schema: {
+              ...restSchema,
+              ...oneOf[1],
+            },
+            description: replacementParameter.alias.description,
+            [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name,
           });
         }
 

--- a/utils/transformers/expandOneOfQueryParametersTransformer.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.js
@@ -16,49 +16,59 @@ function getSuffix(schema) {
  * Expands query parameters whose schema uses `oneOf` into one parameter per option.
  * The first option retains the original parameter name; subsequent options are named
  * `<originalName>_<suffix>` where the suffix is derived from the option's format or type.
- * @param {Record<string, unknown>} apiDefinition
+ *
+ * Use the `includeParams` parameter to only apply the transformer to parameters with a specific name
+ *
+ * @param {string[]} includeParams
  */
-export function expandOneOfQueryParametersTransformer(apiDefinition) {
-  const paths = apiDefinition?.paths;
-  if (!paths || typeof paths !== 'object') {
-    return;
-  }
-
-  for (const pathItem of Object.values(paths)) {
-    if (!pathItem || typeof pathItem !== 'object') {
-      continue;
+export function expandOneOfQueryParametersTransformer(includeParams = []) {
+  return function (apiDefinition) {
+    const paths = apiDefinition?.paths;
+    if (!paths || typeof paths !== 'object') {
+      return;
     }
 
-    for (const operation of Object.values(pathItem)) {
-      if (!operation || typeof operation !== 'object' || !Array.isArray(operation.parameters)) {
+    for (const pathItem of Object.values(paths)) {
+      if (!pathItem || typeof pathItem !== 'object') {
         continue;
       }
 
-      const expanded = [];
-      for (const param of operation.parameters) {
-        if (param.in !== 'query' || !param.schema || !Array.isArray(param.schema.oneOf)) {
-          expanded.push(param);
+      for (const operation of Object.values(pathItem)) {
+        if (!operation || typeof operation !== 'object' || !Array.isArray(operation.parameters)) {
           continue;
         }
 
-        const { oneOf, ...restSchema } = param.schema;
-        const { schema, ...restParam } = param;
-        void schema; // schema is unused
+        const expanded = [];
+        for (const param of operation.parameters) {
+          if (param.in !== 'query' || !param.schema || !Array.isArray(param.schema.oneOf)) {
+            expanded.push(param);
+            continue;
+          }
 
-        oneOf.forEach((option, index) => {
-          const name = index === 0 ? param.name : `${param.name}_${getSuffix(option)}`;
-          expanded.push({
-            ...restParam,
-            name,
-            schema: { ...restSchema, ...option },
-            // Add a vendor extension to the newly added parameters to indicate they are aliases the first
-            // parameter.
-            ...(index === 0 ? {} : { [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name }),
+          if (includeParams.length > 0 && !includeParams.includes(param.name)) {
+            expanded.push(param);
+            continue;
+          }
+
+          const { oneOf, ...restSchema } = param.schema;
+          const { schema, ...restParam } = param;
+          void schema; // schema is unused
+
+          oneOf.forEach((option, index) => {
+            const name = index === 0 ? param.name : `${param.name}_${getSuffix(option)}`;
+            expanded.push({
+              ...restParam,
+              name,
+              schema: { ...restSchema, ...option },
+              // Add a vendor extension to the newly added parameters to indicate they are aliases the first
+              // parameter.
+              ...(index === 0 ? {} : { [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name }),
+            });
           });
-        });
-      }
+        }
 
-      operation.parameters = expanded;
+        operation.parameters = expanded;
+      }
     }
-  }
+  };
 }

--- a/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
@@ -8,7 +8,18 @@ const schemaWithOneOfQueryParameterTransformed = fs.readFileSync(
   './utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml'
 );
 
-const applyTransformer = (yaml) => transformSchema(yaml, [expandOneOfQueryParametersTransformer(['timestamp'])]);
+const replacementParametersMap = {
+  timestamp: {
+    overrideDescription: 'The updated description',
+    alias: {
+      name: 'timestamp_alias',
+      description: 'The description for the alias',
+    },
+  },
+};
+
+const applyTransformer = (yaml) =>
+  transformSchema(yaml, [expandOneOfQueryParametersTransformer(replacementParametersMap)]);
 
 describe('Test expandOneOfQueryParametersTransformer', () => {
   it('does not modify schema without oneOf query parameters', () => {

--- a/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
@@ -8,7 +8,7 @@ const schemaWithOneOfQueryParameterTransformed = fs.readFileSync(
   './utils/mocks/schemaWithOneOfQueryParameterTransformed.yaml'
 );
 
-const applyTransformer = (yaml) => transformSchema(yaml, [expandOneOfQueryParametersTransformer]);
+const applyTransformer = (yaml) => transformSchema(yaml, [expandOneOfQueryParametersTransformer(['timestamp'])]);
 
 describe('Test expandOneOfQueryParametersTransformer', () => {
   it('does not modify schema without oneOf query parameters', () => {

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -1,0 +1,24 @@
+import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParametersTransformer.js';
+
+const replacementParametersMap = {
+  start: {
+    overrideDescription:
+      "Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.",
+    alias: {
+      name: 'start_date_time',
+      description: 'An alias for the `start` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.',
+    },
+  },
+  end: {
+    overrideDescription:
+      "Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed.",
+    alias: {
+      name: 'end_date_time',
+      description: 'An alias for the `end` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.',
+    },
+  },
+};
+
+export function replaceStartEndQueryParameters() {
+  return expandOneOfQueryParametersTransformer(replacementParametersMap);
+}

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -3,18 +3,20 @@ import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParamet
 const replacementParametersMap = {
   start: {
     overrideDescription:
-      "Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change the default of `now` for `end`/`end_date_time` — adjust it separately if needed.",
+      'Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change the default of `now` for `end`/`end_date_time` — adjust it separately if needed.',
     alias: {
       name: 'start_date_time',
-      description: "Include events that happened after this point (with timestamp greater than or equal to the provided `start_date_time` RFC3339 timestamp). Defaults to 7 days ago. Setting `start_date_time` does not the default of `now` for `end`/`end_date_time` — adjust it separately if needed. This parameter is an alias for `start`."
+      description:
+        'Include events that happened after this point (with timestamp greater than or equal to the provided `start_date_time` RFC3339 timestamp). Defaults to 7 days ago. Setting `start_date_time` does not the default of `now` for `end`/`end_date_time` — adjust it separately if needed. This parameter is an alias for `start`.',
     },
   },
   end: {
     overrideDescription:
-      "Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.",
+      'Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.',
     alias: {
       name: 'end_date_time',
-      description: "Include events that happened before this point (with timestamp less than or equal the provided `end_date_time` RFC3339 timestamp). Defaults to now. Setting `end_date_time` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed. This parameter is an alias for `end`."
+      description:
+        'Include events that happened before this point (with timestamp less than or equal the provided `end_date_time` RFC3339 timestamp). Defaults to now. Setting `end_date_time` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed. This parameter is an alias for `end`.',
     },
   },
 };

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -3,18 +3,18 @@ import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParamet
 const replacementParametersMap = {
   start: {
     overrideDescription:
-      "Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.",
+      "Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change the default of `now` for `end`/`end_date_time` — adjust it separately if needed.",
     alias: {
       name: 'start_date_time',
-      description: 'An alias for the `start` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.',
+      description: "Include events that happened after this point (with timestamp greater than or equal to the provided `start_date_time` RFC3339 timestamp). Defaults to 7 days ago. Setting `start_date_time` does not the default of `now` for `end`/`end_date_time` — adjust it separately if needed. This parameter is an alias for `start`."
     },
   },
   end: {
     overrideDescription:
-      "Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed.",
+      "Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.",
     alias: {
       name: 'end_date_time',
-      description: 'An alias for the `end` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.',
+      description: "Include events that happened before this point (with timestamp less than or equal the provided `end_date_time` RFC3339 timestamp). Defaults to now. Setting `end_date_time` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed. This parameter is an alias for `end`."
     },
   },
 };

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -15,7 +15,6 @@ import { parseYaml } from './parseYaml.js';
 import { removeUnusedSchemasTransformer } from './removeUnusedSchemasTransformer.js';
 import { liftOneOfSharedPropertiesTransformer } from './liftOneOfSharedPropertiesTransformer.js';
 import { removeFieldByPathTransformer } from './removeFieldByPathTransformer.js';
-import { removeObjectByPathTransformer } from './removeObjectByPathTransformer.js';
 import { inlineReferencedPropertiesTransformer } from './inlineReferencedPropertiesTransformer.js';
 
 export const commonTransformers = [
@@ -48,26 +47,18 @@ export const v4SchemaForSdksCommonTransformers = [
 
 export const v4SchemaForSdksTransformers = [
   ...v4SchemaForSdksCommonTransformers,
-
-  // The following transformers temporarily remove some fields to unblock server SDK releases
-  // Remove the use of oneOf for start and end query parameters
-  expandOneOfQueryParametersTransformer,
-  removeObjectByPathTransformer(
-    ['paths', '/events', 'get', 'parameters', '*'],
-    (parameter) => parameter.name === 'start_date_time' || parameter.name === 'end_date_time'
-  ),
-  // Inline enums previously extracted from BotInfo to avoid breaking changes in the SDKs
-  inlineReferencedPropertiesTransformer('BotInfo'),
-  // Remove the added enum attribute for BotInfo.category
-  removeFieldByPathTransformer(['components', 'schemas', 'BotInfo', 'properties', 'category', 'enum']),
-
   // This transformer should run last to ensure all unused schemas are found
   removeUnusedSchemasTransformer,
 ];
 
 export const v4SchemaForSdksNormalizedTransformers = [
   ...v4SchemaForSdksCommonTransformers,
+  // Expand oneOf query parameters to avoid breaking changes in the SDKs using this schema
   expandOneOfQueryParametersTransformer,
+  // Inline enums previously extracted from BotInfo to avoid breaking changes in the SDKs using this schema
+  inlineReferencedPropertiesTransformer('BotInfo'),
+  // Remove the added enum attribute for BotInfo.category. This must follow the inline transformer on the previous line.
+  removeFieldByPathTransformer(['components', 'schemas', 'BotInfo', 'properties', 'category', 'enum']),
   // This transformer should run last to ensure all unused schemas are found
   removeUnusedSchemasTransformer,
 ];

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -54,7 +54,7 @@ export const v4SchemaForSdksTransformers = [
 export const v4SchemaForSdksNormalizedTransformers = [
   ...v4SchemaForSdksCommonTransformers,
   // Expand oneOf query parameters to avoid breaking changes in the SDKs using this schema
-  expandOneOfQueryParametersTransformer,
+  expandOneOfQueryParametersTransformer(['start', 'end']),
   // Inline enums previously extracted from BotInfo to avoid breaking changes in the SDKs using this schema
   inlineReferencedPropertiesTransformer('BotInfo'),
   // Remove the added enum attribute for BotInfo.category. This must follow the inline transformer on the previous line.

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -2,7 +2,6 @@ import yaml from 'js-yaml';
 import process from 'node:process';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
-import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParametersTransformer.js';
 import { removeWebhookTransformer } from './removeWebhookTransformer.js';
 import { replaceTagsTransformer } from './replaceTagsTransformer.js';
 import { removeBigExamplesTransformer } from './removeBigExamplesTransformer.js';
@@ -17,6 +16,7 @@ import { removeUnusedSchemasTransformer } from './removeUnusedSchemasTransformer
 import { liftOneOfSharedPropertiesTransformer } from './liftOneOfSharedPropertiesTransformer.js';
 import { removeFieldByPathTransformer } from './removeFieldByPathTransformer.js';
 import { inlineReferencedPropertiesTransformer } from './inlineReferencedPropertiesTransformer.js';
+import { replaceStartEndQueryParameters } from './replaceStartEndQueryParameters.js';
 
 export const commonTransformers = [
   resolveRefTransformer({ schemaPath: './schemas' }),
@@ -54,8 +54,8 @@ export const v4SchemaForSdksTransformers = [
 
 export const v4SchemaForSdksNormalizedTransformers = [
   ...v4SchemaForSdksCommonTransformers,
-  // Expand oneOf query parameters to avoid breaking changes in the SDKs using this schema
-  expandOneOfQueryParametersTransformer(['start', 'end']),
+  // Expand oneOf query parameters, start and end, to avoid breaking changes in the SDKs using this schema
+  replaceStartEndQueryParameters(),
   // Inline enums previously extracted from BotInfo to avoid breaking changes in the SDKs using this schema
   inlineReferencedPropertiesTransformer('BotInfo'),
   // Remove the added enum attribute for BotInfo.category. This must follow the inline transformer on the previous line.

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -1,4 +1,5 @@
 import yaml from 'js-yaml';
+import process from 'node:process';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
 import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParametersTransformer.js';
@@ -87,13 +88,18 @@ export const schemaForSdksTransformers = [
 ];
 
 export function transformSchema(content, transformers = defaultTransformers) {
-  const apiDefinition = parseYaml(content);
+  try {
+    const apiDefinition = parseYaml(content);
 
-  transformers.forEach((transformer) => {
-    transformer(apiDefinition);
-  });
+    transformers.forEach((transformer) => {
+      transformer(apiDefinition);
+    });
 
-  return yaml.dump(apiDefinition, {
-    noRefs: true,
-  });
+    return yaml.dump(apiDefinition, {
+      noRefs: true,
+    });
+  } catch (error) {
+    console.error('Failed to transform schema', error);
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
Itemized changes:
- Add a catch block to `transformSchema` that will invoke `process.exit(1)` when a transformer throws an error. Throwing an error from a transformer does not fail the build. This is likely a bug in the CopyWebpackPlugin.
- Update the sync-server-side-sdks-schema to use the normalized schema for Go, Java and .NET.
- Update the transformers for the normalized schema to:
  - Expand `oneOf` query parameters to multiple query parameters
  - Inline enums that were extracted from `BotInfo`
  - Remove the `enum` attribute for `BotInfo.category`
- Update the transformers for the `fingerprint-server-api-v4` schema to remove temporary workarounds to avoid breaking changes in the SDKs
- Update `expandOneOfQueryParametersTransformer` to perform a very specific transformation on query parameters that use `oneOf`. The transformer now requires the parameters to replace by name, descriptions to override for the parameters, and defined names for the alias parameter.
- Update `expandOneOfQueryParametersTransformer` to add a vendor extension, `x-aliased-parameter-name`, to the added query parameters. This will allow generators to map the extra query parameters back to the aliased parameter when sending actual requests to the API.
- Update `expandOneOfQueryParametersTransformer` to expand into two parameters exactly: a primary and an alias.
- Update `expandOneOfQueryParametersTransformer` to set an additional vendor extension on the original parameter to indicate that it has an alias.

To illustrate how the `x-aliased-parameter-name` and `x-parameter-alias` extensions will be used, here is a diff of using the normalized schema built from this PR with the Java SDK and updated templates to use the extensions:

```diff
diff --git a/sdk/src/main/java/com/fingerprint/v4/api/FingerprintApi.java b/sdk/src/main/java/com/fingerprint/v4/api/FingerprintApi.java
index e49a9e5..2e06b92 100644
--- a/sdk/src/main/java/com/fingerprint/v4/api/FingerprintApi.java
+++ b/sdk/src/main/java/com/fingerprint/v4/api/FingerprintApi.java
@@ -15,6 +15,7 @@ import com.fingerprint.v4.sdk.Configuration;
 import com.fingerprint.v4.sdk.Pair;
 import com.fingerprint.v4.sdk.Region;
 import jakarta.ws.rs.core.GenericType;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -282,7 +283,9 @@ public class FingerprintApi {
     private String packageName;
     private String origin;
     private Long start;
+    private OffsetDateTime startDateTime;
     private Long end;
+    private OffsetDateTime endDateTime;
     private Boolean reverse;
     private Boolean suspect;
     private Boolean vpn;
@@ -495,22 +498,53 @@ public class FingerprintApi {
     }
 
     /**
-     * getter for start - Include events that happened after this point (with timestamp greater than or equal the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.
+     * getter for start - Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.
+     *
+     * @see {@link getStartDateTime}
      */
     public Long getStart() {
       return start;
     }
 
     /**
-     * setter for start - Include events that happened after this point (with timestamp greater than or equal the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.
+     * setter for start - Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.
+     *
+     * To account for parameter aliasing, invoking {@link setStart} will also invoke `setStartDateTime(null)` to clear an existing `start_date_time` parameter value.
+     *
+     * @see {@link setStartDateTime}
      */
     public SearchEventsOptionalParams setStart(Long start) {
       this.start = start;
+      setStartDateTime(null);
+      return this;
+    }
+
+    /**
+     * getter for startDateTime - An alias for the `start` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.
+     *
+     * @see {@link getStart}
+     */
+    public OffsetDateTime getStartDateTime() {
+      return startDateTime;
+    }
+
+    /**
+     * setter for startDateTime - An alias for the `start` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.
+     *
+     * To account for parameter aliasing, invoking {@link setStartDateTime} will also invoke `setStart(null)` to clear an existing `start` parameter value.
+     *
+     * @see {@link setStart}
+     */
+    public SearchEventsOptionalParams setStartDateTime(OffsetDateTime startDateTime) {
+      this.startDateTime = startDateTime;
+      setStart(null);
       return this;
     }
 
     /**
      * getter for end - Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed.
+     *
+     * @see {@link getEndDateTime}
      */
     public Long getEnd() {
       return end;
@@ -518,9 +552,36 @@ public class FingerprintApi {
 
     /**
      * setter for end - Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed.
+     *
+     * To account for parameter aliasing, invoking {@link setEnd} will also invoke `setEndDateTime(null)` to clear an existing `end_date_time` parameter value.
+     *
+     * @see {@link setEndDateTime}
      */
     public SearchEventsOptionalParams setEnd(Long end) {
       this.end = end;
+      setEndDateTime(null);
+      return this;
+    }
+
+    /**
+     * getter for endDateTime - An alias for the `end` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.
+     *
+     * @see {@link getEnd}
+     */
+    public OffsetDateTime getEndDateTime() {
+      return endDateTime;
+    }
+
+    /**
+     * setter for endDateTime - An alias for the `end` that accepts an RFC3339 timestamp rather than a UNIX milliseconds value.
+     *
+     * To account for parameter aliasing, invoking {@link setEndDateTime} will also invoke `setEnd(null)` to clear an existing `end` parameter value.
+     *
+     * @see {@link setEnd}
+     */
+    public SearchEventsOptionalParams setEndDateTime(OffsetDateTime endDateTime) {
+      this.endDateTime = endDateTime;
+      setEnd(null);
       return this;
     }
 
@@ -1056,8 +1117,12 @@ public class FingerprintApi {
           apiClient.parameterToPairs("", "origin", searchEventsOptionalParams.getOrigin()));
       localVarQueryParams.addAll(
           apiClient.parameterToPairs("", "start", searchEventsOptionalParams.getStart()));
+      localVarQueryParams.addAll(
+          apiClient.parameterToPairs("", "start", searchEventsOptionalParams.getStartDateTime()));
       localVarQueryParams.addAll(
           apiClient.parameterToPairs("", "end", searchEventsOptionalParams.getEnd()));
+      localVarQueryParams.addAll(
+          apiClient.parameterToPairs("", "end", searchEventsOptionalParams.getEndDateTime()));
       localVarQueryParams.addAll(
           apiClient.parameterToPairs("", "reverse", searchEventsOptionalParams.getReverse()));
       localVarQueryParams.addAll(
```

Fixes INTER-2031
Fixes INTER-2032
Fixes INTER-2033
Fixes INTER-2042