### PR TITLE
Add proxy mlScore to v3 schemas

### DIFF
--- a/schemas/fingerprint-server-api-for-sdks.yaml
+++ b/schemas/fingerprint-server-api-for-sdks.yaml
@@ -256,6 +256,7 @@ paths:
                         data:
                           result: true
                           confidence: high
+                          mlScore: 0.99
                           details:
                             proxyType: residential
                             lastSeenAt: '2025-08-12T13:00:00Z'
@@ -1371,6 +1372,7 @@ paths:
                             data:
                               result: false
                               confidence: high
+                              mlScore: 0.7
                               details:
                                 proxyType: residential
                                 lastSeenAt: '2025-08-12T13:00:00Z'
@@ -4845,6 +4847,7 @@ paths:
                           proxy:
                             result: true
                             confidence: high
+                            mlScore: 0.99
                             details:
                               proxyType: residential
                               lastSeenAt: '2025-08-12T13:00:00Z'
@@ -5765,6 +5768,19 @@ components:
           $ref: '#/components/schemas/ProxyConfidence'
         details:
           $ref: '#/components/schemas/ProxyDetails'
+        mlScore:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Machine learning-based proxy score, represented as a floating-point
+            value between 0 and 1 (inclusive), with up to three decimal places
+            of precision. A higher score means a higher confidence in the
+            positive `proxy` detection result. This Smart Signal is currently in
+            beta and only available to select customers. If you are interested,
+            please [contact our support
+            team](https://fingerprint.com/support/).
     ProductProxy:
       type: object
       additionalProperties: false
@@ -6644,6 +6660,19 @@ components:
           $ref: '#/components/schemas/ProxyConfidence'
         details:
           $ref: '#/components/schemas/ProxyDetails'
+        mlScore:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Machine learning-based proxy score, represented as a floating-point
+            value between 0 and 1 (inclusive), with up to three decimal places
+            of precision. A higher score means a higher confidence in the
+            positive `proxy` detection result. This Smart Signal is currently in
+            beta and only available to select customers. If you are interested,
+            please [contact our support
+            team](https://fingerprint.com/support/).
     WebhookTampering:
       type: object
       additionalProperties: false

--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -264,6 +264,7 @@ paths:
                         data:
                           result: true
                           confidence: high
+                          mlScore: 0.99
                           details:
                             proxyType: residential
                             lastSeenAt: '2025-08-12T13:00:00Z'
@@ -1789,6 +1790,7 @@ paths:
                             data:
                               result: false
                               confidence: high
+                              mlScore: 0.7
                               details:
                                 proxyType: residential
                                 lastSeenAt: '2025-08-12T13:00:00Z'
@@ -6278,6 +6280,19 @@ components:
           $ref: '#/components/schemas/ProxyConfidence'
         details:
           $ref: '#/components/schemas/ProxyDetails'
+        mlScore:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Machine learning-based proxy score, represented as a floating-point
+            value between 0 and 1 (inclusive), with up to three decimal places
+            of precision. A higher score means a higher confidence in the
+            positive `proxy` detection result. This Smart Signal is currently in
+            beta and only available to select customers. If you are interested,
+            please [contact our support
+            team](https://fingerprint.com/support/).
     ProductProxy:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Summary
- Add missing `mlScore` property to `Proxy` and `WebhookProxy` schemas in the v3 API spec
- Update response examples to include `mlScore` values
- Aligns v3 schemas (for-sdks, readme-explorer) with the koala source of truth
