### PR TITLE
INTER-2126: exclude /edge from v4 SDK schema outputs

### DIFF
--- a/utils/transformers/removeEdgeTransformer.js
+++ b/utils/transformers/removeEdgeTransformer.js
@@ -1,0 +1,4 @@
+// Removes the Edge API endpoint from SDK schema outputs (documented in v4-with-examples only)
+export function removeEdgeTransformer(apiDefinition) {
+  delete apiDefinition.paths['/edge'];
+}

--- a/utils/transformers/removeEdgeTransformer.spec.js
+++ b/utils/transformers/removeEdgeTransformer.spec.js
@@ -1,0 +1,36 @@
+import { parseYaml } from './parseYaml.js';
+import { transformSchema } from './transformSchema.js';
+import { removeEdgeTransformer } from './removeEdgeTransformer.js';
+
+const yamlWithEdge = `
+openapi: 3.1.1
+paths:
+  /events:
+    get: {}
+  /edge:
+    post: {}
+`;
+
+describe('removeEdgeTransformer', () => {
+  it('removes /edge from paths', () => {
+    const result = transformSchema(yamlWithEdge, [removeEdgeTransformer]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/edge']).toBeUndefined();
+    expect(parsed.paths['/events']).toBeDefined();
+  });
+
+  it('is a no-op when /edge is absent', () => {
+    const yamlWithoutEdge = `
+openapi: 3.1.1
+paths:
+  /events:
+    get: {}
+`;
+    const result = transformSchema(yamlWithoutEdge, [removeEdgeTransformer]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/events']).toBeDefined();
+    expect(Object.keys(parsed.paths)).toEqual(['/events']);
+  });
+});

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -3,6 +3,7 @@ import process from 'node:process';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.js';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.js';
 import { removeWebhookTransformer } from './removeWebhookTransformer.js';
+import { removeEdgeTransformer } from './removeEdgeTransformer.js';
 import { replaceTagsTransformer } from './replaceTagsTransformer.js';
 import { removeBigExamplesTransformer } from './removeBigExamplesTransformer.js';
 import { removeFieldTransformer } from './removeFieldTransformer.js';
@@ -38,6 +39,7 @@ export const v4Transformers = [
 
 export const v4SchemaForSdksCommonTransformers = [
   ...v4Transformers,
+  removeEdgeTransformer,
   extractPathOperationInlineEnumsTransformer,
   replaceTagsTransformer,
   removeFieldTransformer('webhooks'),

--- a/utils/transformers/transformSchema.spec.js
+++ b/utils/transformers/transformSchema.spec.js
@@ -79,6 +79,33 @@ describe('Test transformSchema pipelines for v4', () => {
     });
   });
 
+  it('v4 docs schema keeps /edge when present', () => {
+    const yamlWithEdge = toYaml({
+      openapi: '3.1.1',
+      paths: { '/edge': { post: {} }, '/events': { get: {} } },
+      components: { schemas: {} },
+    });
+
+    const result = transformSchema(yamlWithEdge, [...v4Transformers]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/edge']).toBeDefined();
+  });
+
+  it('v4 sdk schemas remove /edge when present', () => {
+    const yamlWithEdge = toYaml({
+      openapi: '3.1.1',
+      paths: { '/edge': { post: {} }, '/events': { get: {} } },
+      components: { schemas: {} },
+    });
+
+    for (const transformers of [v4SchemaForSdksTransformers, v4SchemaForSdksNormalizedTransformers]) {
+      const result = transformSchema(yamlWithEdge, transformers);
+      const parsed = parseYaml(result);
+      expect(parsed.paths['/edge']).toBeUndefined();
+    }
+  });
+
   it('v4 normalized sdk schema removes examples, additionalProperties: false, oneOf query parameters', () => {
     const result = transformSchema(v4Schema, v4SchemaForSdksNormalizedTransformers);
 


### PR DESCRIPTION
[INTER-2126](https://fingerprintjs.atlassian.net/browse/INTER-2126)

- Add `removeEdgeTransformer` to drop `paths['/edge']` from v4 SDK build outputs
- Wire it into `v4SchemaForSdksCommonTransformers` (both `fingerprint-server-api-v4.yaml` and `fingerprint-server-api-v4-normalized.yaml`)
- Leave `/edge` in `fingerprint-server-api-v4-with-examples.yaml` (`v4Transformers` only)
- Add unit and pipeline tests

[INTER-2126]: https://fingerprintjs.atlassian.net/browse/INTER-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ