### PR TITLE
Sync OpenAPI Schema (99999)

### DIFF
--- a/schemas/components/schemas/smartsignals/VpnMethods.yaml
+++ b/schemas/components/schemas/smartsignals/VpnMethods.yaml
@@ -55,3 +55,13 @@ properties:
     x-ruleset-metadata:
       label: VPN method - relay
       category: ip_address
+  datacenter:
+    type: boolean
+    x-platforms:
+      - android
+      - ios
+      - browser
+    description: Request IP address belongs to a hosting or datacenter provider, which is commonly associated with VPN and proxy services.
+    x-ruleset-metadata:
+      label: VPN method - datacenter
+      category: ip_address


### PR DESCRIPTION
**Test PR — do not merge.**

Opened to verify the `ai-prep-sync-pr.yml` workflow (PR #355) now that `ANTHROPIC_API_KEY` is configured.

- Base is `claude/magical-goldberg-yzwj81`, which carries the workflow with a **temporarily relaxed** author guard (allows `JuroUhlar` in addition to the sync bot) so this manually opened PR can trigger the `prep` job.
- Head carries a single realistic additive schema change: a new `datacenter` field on `VpnMethods`, with **no changeset** — so the idempotency guard should not skip, and the Claude Code step should generate one.

### What to watch
1. `AI prep sync PR` workflow runs (job not skipped).
2. Claude writes a changeset under `.changeset/`, `pnpm lint:changesets` passes.
3. The PR title gains a `- <caption>` suffix.
4. A 🤖 reviewer note is posted.

Revert the author-guard relaxation before merging #355.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbYHHe2wNHVKBxcTHSr8Rc)_