### PR TITLE
Sync OpenAPI Schema (99998)

### DIFF
--- a/schemas/components/schemas/smartsignals/VpnMethods.yaml
+++ b/schemas/components/schemas/smartsignals/VpnMethods.yaml
@@ -55,3 +55,13 @@ properties:
     x-ruleset-metadata:
       label: VPN method - relay
       category: ip_address
+  datacenter:
+    type: boolean
+    x-platforms:
+      - android
+      - ios
+      - browser
+    description: Request IP address belongs to a hosting or datacenter provider, which is commonly associated with VPN and proxy services.
+    x-ruleset-metadata:
+      label: VPN method - datacenter
+      category: ip_address


### PR DESCRIPTION
**Test PR #2 — do not merge.**

Re-test of the `ai-prep-sync-pr.yml` workflow after fixing the OIDC failure found in #393.

**Fix under test:** the Claude Code action now receives `github_token: ${{ steps.app-token.outputs.token }}`, so it no longer falls back to minting a token via OIDC (which failed in #393 with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` — the job lacks `id-token: write`).

Same as #393 otherwise: base carries the **temporarily relaxed** author guard; head adds a single `datacenter` field to `VpnMethods` with no changeset.

### What to watch
1. `AI prep sync PR` job runs and the Claude step completes.
2. A changeset appears under `.changeset/`, `pnpm lint:changesets` passes.
3. Title gains a `- <caption>` suffix; 🤖 reviewer note posts.

Both this relaxation and (if it works) the `github_token` fix should be ported to PR #355.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbYHHe2wNHVKBxcTHSr8Rc)_