### PR TITLE
Sync OpenAPI Schema (99997)

### DIFF
--- a/.changeset/vpn-methods-datacenter.md
+++ b/.changeset/vpn-methods-datacenter.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': minor
+---
+
+**events**: Add `datacenter` field to `VpnMethods`

--- a/schemas/components/schemas/smartsignals/VpnMethods.yaml
+++ b/schemas/components/schemas/smartsignals/VpnMethods.yaml
@@ -55,3 +55,13 @@ properties:
     x-ruleset-metadata:
       label: VPN method - relay
       category: ip_address
+  datacenter:
+    type: boolean
+    x-platforms:
+      - android
+      - ios
+      - browser
+    description: Request IP address belongs to a hosting or datacenter provider, which is commonly associated with VPN and proxy services.
+    x-ruleset-metadata:
+      label: VPN method - datacenter
+      category: ip_address


### PR DESCRIPTION
**Test PR #3 — do not merge.**

Re-test after bumping `claude-code-action` to **v1.0.154** (fixes the `ENOENT … symlink` crash from #394, caused by `CLAUDE.md` being a symlink to `AGENTS.md`).

Base carries: temporarily relaxed author guard + `github_token` fix + the action version bump. Head adds the `datacenter` field to `VpnMethods` with no changeset.

### Expected if it works end-to-end
1. `AI prep sync PR` job runs Claude with no OIDC/symlink errors.
2. A changeset appears under `.changeset/`, `pnpm lint:changesets` passes.
3. PR title gains a `- <caption>` suffix; 🤖 reviewer note posts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbYHHe2wNHVKBxcTHSr8Rc)_