### PR TITLE
Sync OpenAPI Schema (99996) - events: Add datacenter field to VpnMethods

### DIFF
--- a/.changeset/vpn-methods-datacenter.md
+++ b/.changeset/vpn-methods-datacenter.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': minor
+---
+
+**events**: Add `datacenter` field to `VpnMethods`

--- a/schemas/components/schemas/smartsignals/VpnMethods.yaml
+++ b/schemas/components/schemas/smartsignals/VpnMethods.yaml
@@ -55,3 +55,13 @@ properties:
     x-ruleset-metadata:
       label: VPN method - relay
       category: ip_address
+  datacenter:
+    type: boolean
+    x-platforms:
+      - android
+      - ios
+      - browser
+    description: Request IP address belongs to a hosting or datacenter provider, which is commonly associated with VPN and proxy services.
+    x-ruleset-metadata:
+      label: VPN method - datacenter
+      category: ip_address


### PR DESCRIPTION
**Test PR #4 — do not merge.**

Final verification that the **file-based title-rename fix** works in a live run (the one gap from #395). Base carries the same workflow now on #355 (`github_token` + v1.0.154 + `pr-caption.txt`), plus the test-only author-guard relaxation.

### Expected
1. Claude writes a changeset under `.changeset/` and `pr-caption.txt`.
2. The job renames this PR to `Sync OpenAPI Schema (99996) - <caption>`.
3. 🤖 reviewer note posts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbYHHe2wNHVKBxcTHSr8Rc)_