### PR TITLE
ci: allow sync bot to trigger ai-prep workflow

### DIFF
--- a/.github/workflows/ai-prep-sync-pr.yml
+++ b/.github/workflows/ai-prep-sync-pr.yml
@@ -90,6 +90,10 @@ jobs:
           # OIDC (which would require `id-token: write` and the Claude GitHub App).
           github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # This workflow only ever runs on sync PRs opened by this bot (see the
+          # `guard` job). Allow that bot to trigger the action; otherwise the
+          # action's human-actor check rejects the bot-initiated run.
+          allowed_bots: 'fingerprint-dx-team-actions-runner[bot]'
           claude_args: '--allowed-tools Bash,Read,Write,Edit'
           prompt: |
             You are preparing a sync PR for human review. The PR was opened by a bot


### PR DESCRIPTION
Fixes: https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/28133645730/job/83315533838?pr=398


- Add `allowed_bots: 'fingerprint-dx-team-actions-runner[bot]'` to the [Run Claude Code step](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/blob/main/.github/workflows/ai-prep-sync-pr.yml) so bot-opened sync PRs pass the action's human-actor check.

Fixes the `AI prep sync PR` workflow, which failed with `Workflow initiated by non-human actor: fingerprint-dx-team-actions-runner (type: Bot)`. `claude-code-action` v1.0.154 rejects non-`User` actors unless allowlisted, but this workflow's [`guard` job](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/blob/main/.github/workflows/ai-prep-sync-pr.yml#L9-L11) only ever runs for that exact bot.

### Won't fix the current failing run

Takes effect only on a newly-opened sync PR after this merges to `main` — the workflow triggers on `pull_request: opened` and reads its YAML from the merge commit. Re-running the existing failed run reuses the old workflow version.