### PR TITLE
SPIKE PROTOTYPE [INTER-2230]: Edit on GitHub links for Server API v4 reference

### DIFF
--- a/.changeset/add-parameter-example.md
+++ b/.changeset/add-parameter-example.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': patch
+---
+
+Add `example` properties for operation parameters to SDK schemas

--- a/utils/mocks/schemaWithExamples.yaml
+++ b/utils/mocks/schemaWithExamples.yaml
@@ -11,7 +11,13 @@ paths:
           required: true
           schema:
             type: string
-          example: mcEozNgqhKgmfXx7ZaMW
+          examples:
+            - mcEozNgqhKgmfXx7ZaMW
+        - name: event_id
+          in: query
+          schema:
+            type: string
+          example: 1708102555327.NLOjmg
       responses:
         '200':
           description: Auto generated using Swagger Inspector
@@ -36,3 +42,10 @@ components:
         - visitorId
         - visits
       title: Response
+    Model:
+      type: object
+      properties:
+        id:
+          type: string
+          examples:
+            - sample_id

--- a/utils/mocks/schemaWithExamples.yaml
+++ b/utils/mocks/schemaWithExamples.yaml
@@ -11,13 +11,19 @@ paths:
           required: true
           schema:
             type: string
-          examples:
-            - mcEozNgqhKgmfXx7ZaMW
+            examples:
+              - mcEozNgqhKgmfXx7ZaMW
         - name: event_id
           in: query
           schema:
             type: string
-          example: 1708102555327.NLOjmg
+            example: 1708102555327.NLOjmg
+        - name: value
+          in: query
+          schema:
+            type: number
+            examples:
+              - 0
       responses:
         '200':
           description: Auto generated using Swagger Inspector

--- a/utils/mocks/schemaWithExamplesCleaned.yaml
+++ b/utils/mocks/schemaWithExamplesCleaned.yaml
@@ -11,6 +11,8 @@ paths:
           required: true
           schema:
             type: string
+            examples:
+              - mcEozNgqhKgmfXx7ZaMW
         - name: event_id
           in: query
           schema:
@@ -20,6 +22,8 @@ paths:
           in: query
           schema:
             type: number
+            examples:
+              - 0
       requestBody:
         content:
           application/json:
@@ -51,3 +55,5 @@ components:
       properties:
         id:
           type: string
+          examples:
+            - sample_id

--- a/utils/mocks/schemaWithExamplesCleaned.yaml
+++ b/utils/mocks/schemaWithExamplesCleaned.yaml
@@ -15,7 +15,11 @@ paths:
           in: query
           schema:
             type: string
-          example: 1708102555327.NLOjmg
+            example: 1708102555327.NLOjmg
+        - name: value
+          in: query
+          schema:
+            type: number
       responses:
         '200':
           description: Auto generated using Swagger Inspector

--- a/utils/mocks/schemaWithExamplesNormalized.yaml
+++ b/utils/mocks/schemaWithExamplesNormalized.yaml
@@ -11,14 +11,21 @@ paths:
           required: true
           schema:
             type: string
-          examples:
-            - mcEozNgqhKgmfXx7ZaMW
-          example: mcEozNgqhKgmfXx7ZaMW
+            examples:
+              - mcEozNgqhKgmfXx7ZaMW
+            example: mcEozNgqhKgmfXx7ZaMW
         - name: event_id
           in: query
           schema:
             type: string
-          example: 1708102555327.NLOjmg
+            example: 1708102555327.NLOjmg
+        - name: value
+          in: query
+          schema:
+            type: number
+            examples:
+              - 0
+            example: 0
       responses:
         '200':
           description: Auto generated using Swagger Inspector

--- a/utils/mocks/schemaWithExamplesNormalized.yaml
+++ b/utils/mocks/schemaWithExamplesNormalized.yaml
@@ -11,6 +11,9 @@ paths:
           required: true
           schema:
             type: string
+          examples:
+            - mcEozNgqhKgmfXx7ZaMW
+          example: mcEozNgqhKgmfXx7ZaMW
         - name: event_id
           in: query
           schema:
@@ -23,6 +26,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
+              examples:
+                exampleA:
+                  summary: Example A
+                  value:
+                    visitorId: qwerty
 components:
   schemas:
     Response:
@@ -40,3 +48,5 @@ components:
       properties:
         id:
           type: string
+          examples:
+            - sample_id

--- a/utils/mocks/schemaWithExamplesNormalized.yaml
+++ b/utils/mocks/schemaWithExamplesNormalized.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Fingerprint server API
   version: '0.1'
@@ -26,6 +26,16 @@ paths:
             examples:
               - 0
             example: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Response'
+            examples:
+              requestExample:
+                summary: Request example
+                value:
+                  visitorId: qwerty
       responses:
         '200':
           description: Auto generated using Swagger Inspector
@@ -46,6 +56,8 @@ components:
       properties:
         visitorId:
           type: string
+          examples:
+            - qwerty
       required:
         - visitorId
         - visits

--- a/utils/transformers/extractFirstParameterExampleTransformer.js
+++ b/utils/transformers/extractFirstParameterExampleTransformer.js
@@ -16,7 +16,7 @@ export function extractFirstParameterExampleTransformer(apiDefinition) {
     walkJson(apiDefinition.paths, 'examples', (partWithKey) => {
       if (Array.isArray(partWithKey.examples)) {
         const firstExample = partWithKey.examples[0];
-        if (firstExample) {
+        if (firstExample !== undefined) {
           partWithKey.example = firstExample;
         }
       }

--- a/utils/transformers/extractFirstParameterExampleTransformer.js
+++ b/utils/transformers/extractFirstParameterExampleTransformer.js
@@ -1,0 +1,25 @@
+import { walkJson } from '../walkJson.js';
+
+/**
+ * Extract the first example from the `examples` array, if present, for
+ * all parameters of operations.
+ *
+ * Despite `example` being deprecated in OAS 3.1 and later, the code
+ * generators are still relying on it so this transformer allows a
+ * schema to continue using `example` while migrating to `examples`
+ * in the main schema.
+ *
+ * @param {Record<string, any>} apiDefinition
+ */
+export function extractFirstParameterExampleTransformer(apiDefinition) {
+  if (apiDefinition.paths) {
+    walkJson(apiDefinition.paths, 'examples', (partWithKey) => {
+      if (Array.isArray(partWithKey.examples)) {
+        const firstExample = partWithKey.examples[0];
+        if (firstExample) {
+          partWithKey.example = firstExample;
+        }
+      }
+    });
+  }
+}

--- a/utils/transformers/extractFirstParameterExampleTransformer.spec.js
+++ b/utils/transformers/extractFirstParameterExampleTransformer.spec.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import { transformSchema } from './transformSchema.js';
+import { extractFirstParameterExampleTransformer } from './extractFirstParameterExampleTransformer.js';
+
+const simpleYaml = fs.readFileSync('./utils/mocks/simple.yaml');
+const schemaWithExamples = fs.readFileSync('./utils/mocks/schemaWithExamples.yaml');
+const schemaWithExamplesNormalized = fs.readFileSync('./utils/mocks/schemaWithExamplesNormalized.yaml');
+
+const cleanSchema = (yaml) => transformSchema(yaml, [extractFirstParameterExampleTransformer]);
+describe('extractFirstParameterExampleTransformer', () => {
+  it('don`t need to do anything', () => {
+    const result = cleanSchema(simpleYaml);
+    expect(result.toString()).toEqual(simpleYaml.toString());
+  });
+
+  it('extracts first parameter example', () => {
+    const result = cleanSchema(schemaWithExamples);
+    expect(result.toString()).toEqual(schemaWithExamplesNormalized.toString());
+  });
+});

--- a/utils/transformers/extractFirstParameterExampleTransformer.spec.js
+++ b/utils/transformers/extractFirstParameterExampleTransformer.spec.js
@@ -8,7 +8,7 @@ const schemaWithExamplesNormalized = fs.readFileSync('./utils/mocks/schemaWithEx
 
 const cleanSchema = (yaml) => transformSchema(yaml, [extractFirstParameterExampleTransformer]);
 describe('extractFirstParameterExampleTransformer', () => {
-  it('don`t need to do anything', () => {
+  it("don't need to do anything", () => {
     const result = cleanSchema(simpleYaml);
     expect(result.toString()).toEqual(simpleYaml.toString());
   });

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -18,6 +18,7 @@ import { liftOneOfSharedPropertiesTransformer } from './liftOneOfSharedPropertie
 import { removeFieldByPathTransformer } from './removeFieldByPathTransformer.js';
 import { inlineReferencedPropertiesTransformer } from './inlineReferencedPropertiesTransformer.js';
 import { replaceStartEndQueryParameters } from './replaceStartEndQueryParameters.js';
+import { extractFirstParameterExampleTransformer } from './extractFirstParameterExampleTransformer.js';
 
 export const commonTransformers = [
   resolveRefTransformer({ schemaPath: './schemas' }),
@@ -39,6 +40,7 @@ export const v4Transformers = [
 
 export const v4SchemaForSdksCommonTransformers = [
   ...v4Transformers,
+  extractFirstParameterExampleTransformer,
   removeEdgeTransformer,
   extractPathOperationInlineEnumsTransformer,
   replaceTagsTransformer,


### PR DESCRIPTION
- Add a new transformer, `extractFirstParameterExampleTransformer`, to promote the first element from `examples`, if present, to `example`, for parameters in the SDK schemas. Despite `example` being deprecated, the code generators are still relying on the presence of `example` so it needs to be maintained in the SDK schemas for the time being.
- Update test cases for examples removal and the new transformer