### PR TITLE
chore: exclude edge examples from examples artifact

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,9 @@ const __dirname = path.dirname(__filename);
 
 const outputPath = path.resolve(__dirname, 'dist');
 
+// subdirectories under `schemas/paths/examples` whose examples should not be copied to `dist`
+const excludedExampleDirs = ['edge'];
+
 export default {
   mode: 'development',
   entry: {
@@ -118,6 +121,10 @@ export default {
         {
           from: 'schemas/paths/examples',
           to: 'examples',
+          globOptions: {
+            // subdirectories under `schemas/paths/examples` whose examples should not be copied
+            ignore: excludedExampleDirs.map((/** @type {string} */ dir) => `**/schemas/paths/examples/${dir}/**`),
+          },
         },
         {
           from: 'res/favicon.ico',


### PR DESCRIPTION
- Update the webpack config to exclude the `schemas/paths/examples/edge` examples from the `examples` artifact. `examples.zip` is used by the server SDKs to generate test cases and the edge examples are not relevant to the server SDKs as this time.