### PR TITLE
chore: add packageManager field to package.json

### DIFF
--- a/.github/actions/test-and-build/action.yml
+++ b/.github/actions/test-and-build/action.yml
@@ -16,10 +16,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Install PNPM'
-      uses: pnpm/action-setup@0eb0e970826653e8af98de91bec007fbd58a23e0
-      with:
-        version: 9
+    - name: Install PNPM
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - name: Set Node.js 22.x
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/ai-prep-sync-pr.yml
+++ b/.github/workflows/ai-prep-sync-pr.yml
@@ -67,9 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install PNPM
-        uses: pnpm/action-setup@0eb0e970826653e8af98de91bec007fbd58a23e0
-        with:
-          version: 9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Set Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/lint-changesets.yml
+++ b/.github/workflows/lint-changesets.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install PNPM
-        uses: pnpm/action-setup@0eb0e970826653e8af98de91bec007fbd58a23e0
-        with:
-          version: 9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: Set Node.js 22.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/schema-diff-pr-comment.yml
+++ b/.github/workflows/schema-diff-pr-comment.yml
@@ -24,10 +24,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0eb0e970826653e8af98de91bec007fbd58a23e0
-        with:
-          version: 9
+      - name: Install PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/upload-changesets.yml
+++ b/.github/workflows/upload-changesets.yml
@@ -13,11 +13,8 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
-        with:
-          version: 9
-          run_install: true
+      - name: Install PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Upload an Asset in GitHub Release
         uses: actions/github-script@v7

--- a/.github/workflows/upload-schemas.yml
+++ b/.github/workflows/upload-schemas.yml
@@ -13,11 +13,8 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: 'Install pnpm'
-        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
-        with:
-          version: 9
-          run_install: true
+      - name: Install PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: 'Build schemas'
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "zip-lib": "^1.0.4",
     "znv": "^0.4.0",
     "zod": "^3.23.8"
-  }
+  },
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }


### PR DESCRIPTION
- Add `packageManager` to package.json, pinned to pnpm 9.15.0
- Update the local github workflows to use pnpm/action-setup that uses `packageManager` rather than the `version` input. This aligns with workflows from dx-team-toolkit, which now expect the package.json to define `packageManager`.
- Update the `test-and-build` composite action to use pnpm/action-setup update.

NOTE: a future PR will upgrade to pnpm 11