### PR TITLE
Clarify changeset requirements and version bump guidance

### DIFF
--- a/.github/workflows/ai-prep-sync-pr.yml
+++ b/.github/workflows/ai-prep-sync-pr.yml
@@ -104,11 +104,10 @@ jobs:
 
             Steps:
 
-            1. Read `CLAUDE.md` — it documents the changeset filename, frontmatter,
-               and body format. Follow it exactly. Also read the "Describing
-               changes" section of `CONTRIBUTING.md`, which defines the criteria
-               for whether a change needs a changeset and which version bump
-               (`patch` / `minor` / `major`) to use. Follow that guidance.
+            1. Read `CLAUDE.md` for the changeset filename, frontmatter, and body
+               format, and the "Describing changes" section of `CONTRIBUTING.md`
+               for when a change needs a changeset and which version bump to use.
+               Follow both exactly.
 
             2. Inspect the diff:
                `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- schemas/`
@@ -119,19 +118,17 @@ jobs:
                coherent change, write a single file. Share a filename prefix for
                related entries as CLAUDE.md describes.
 
-               If the diff contains ONLY documentation changes (e.g. descriptions
-               or examples) and no functional schema changes, then per the
-               `CONTRIBUTING.md` guidance no changeset is needed: do not write any
-               changeset file and skip step 6 (leave `pr-caption.txt` unwritten).
+               If nothing in the diff needs a changeset per that guidance (e.g. only
+               documentation changes), don't write a changeset file and skip step 6
+               (leave `pr-caption.txt` unwritten).
 
             4. For each changeset:
                - Identify the scope from: events, visitors, webhook,
                  related-visitors, events-search. If none applies, omit the bold
                  scope prefix.
-               - Pick the version bump (`patch` / `minor` / `major`) using the
-                 criteria from the "Describing changes" section of `CONTRIBUTING.md`.
-                 Sync PRs are additive in the usual case, so `minor` is the most
-                 common; default to `minor` when unsure.
+               - Pick the version bump per `CONTRIBUTING.md`. Sync PRs are usually
+                 additive, so `minor` is the common case; default to `minor` when
+                 unsure.
                - Write the file to `.changeset/<kebab-case-summary>.md`.
 
             5. Verify your work by running `pnpm lint:changesets`. Fix any issues

--- a/.github/workflows/ai-prep-sync-pr.yml
+++ b/.github/workflows/ai-prep-sync-pr.yml
@@ -105,7 +105,10 @@ jobs:
             Steps:
 
             1. Read `CLAUDE.md` — it documents the changeset filename, frontmatter,
-               and body format. Follow it exactly.
+               and body format. Follow it exactly. Also read the "Describing
+               changes" section of `CONTRIBUTING.md`, which defines the criteria
+               for whether a change needs a changeset and which version bump
+               (`patch` / `minor` / `major`) to use. Follow that guidance.
 
             2. Inspect the diff:
                `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- schemas/`
@@ -116,13 +119,19 @@ jobs:
                coherent change, write a single file. Share a filename prefix for
                related entries as CLAUDE.md describes.
 
+               If the diff contains ONLY documentation changes (e.g. descriptions
+               or examples) and no functional schema changes, then per the
+               `CONTRIBUTING.md` guidance no changeset is needed: do not write any
+               changeset file and skip step 6 (leave `pr-caption.txt` unwritten).
+
             4. For each changeset:
                - Identify the scope from: events, visitors, webhook,
                  related-visitors, events-search. If none applies, omit the bold
                  scope prefix.
-               - Pick severity: `patch` (fix/docs), `minor` (additive — the usual
-                 case for sync PRs), `major` (breaking: removed required field,
-                 narrowed type, removed endpoint). Default to `minor` when unsure.
+               - Pick the version bump (`patch` / `minor` / `major`) using the
+                 criteria from the "Describing changes" section of `CONTRIBUTING.md`.
+                 Sync PRs are additive in the usual case, so `minor` is the most
+                 common; default to `minor` when unsure.
                - Write the file to `.changeset/<kebab-case-summary>.md`.
 
             5. Verify your work by running `pnpm lint:changesets`. Fix any issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,15 @@ Example changeset looks like this:
 - `fingerprint-pro-server-api-openapi` - name of the package
 - `minor` - version of the change, can be: `patch`, `minor`, `major`
 
+#### Choosing the version bump
+
+Use the following criteria to decide whether a change needs a changeset and, if so, which version bump to use:
+
+- `major` - a breaking change (e.g. removing a field, schema, endpoint, or query parameter, narrowing a type, or making a previously optional field required). This should be very rare. If you find yourself reaching for `major`, it is likely an accidental change that should be reverted instead.
+- `minor` - a backwards-compatible addition, such as new fields on existing schemas, entirely new schemas, new query parameters, or new paths and methods.
+- `patch` - a backwards-compatible change that is not a new addition, such as deprecating an existing field, or adding vendor extensions or other attributes to existing properties.
+- Documentation-only changes (e.g. editing descriptions or examples) should **not** create a changeset.
+
 ### Publishing changes
 
 On every push into `main` (merged PR):  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,12 +84,13 @@ Example changeset looks like this:
 
 #### Choosing the version bump
 
-Use the following criteria to decide whether a change needs a changeset and, if so, which version bump to use:
+A changeset is only needed when a change affects the generated SDKs. Pick the version bump as follows:
 
-- `major` - a breaking change (e.g. removing a field, schema, endpoint, or query parameter, narrowing a type, or making a previously optional field required). This should be very rare. If you find yourself reaching for `major`, it is likely an accidental change that should be reverted instead.
-- `minor` - a backwards-compatible addition, such as new fields on existing schemas, entirely new schemas, new query parameters, or new paths and methods.
-- `patch` - a backwards-compatible change that is not a new addition, such as deprecating an existing field, or adding vendor extensions or other attributes to existing properties.
-- Documentation-only changes (e.g. editing descriptions or examples) should **not** create a changeset.
+- `major` - a breaking change: removing a field, schema, endpoint, or query parameter, narrowing a type, or making an optional field required. Very rare, and usually an accidental change to revert.
+- `minor` - a backwards-compatible addition: new fields, schemas, query parameters, paths, or methods.
+- `patch` - a backwards-compatible change that isn't an addition, e.g. deprecating a field, or a vendor extension that affects SDK code generation (like `x-parameter-alias` / `x-aliased-parameter-name`).
+
+Don't create a changeset for documentation-only changes (descriptions, examples) or for vendor extensions that don't affect the generated SDKs.
 
 ### Publishing changes
 


### PR DESCRIPTION
Updates documentation to clarify when changesets are needed and how to choose the appropriate version bump.

**Changes:**

- **CONTRIBUTING.md**: Added a new "Choosing the version bump" section that explicitly defines when a changeset is required (only for changes affecting generated SDKs) and provides clear criteria for selecting `major`, `minor`, or `patch` bumps. Includes guidance that documentation-only changes and vendor extensions that don't affect SDK generation should not have changesets.

- **ai-prep-sync-pr.yml**: Updated the AI prompt instructions to:
  - Reference both `CLAUDE.md` and the new "Describing changes" section of `CONTRIBUTING.md` for changeset guidance
  - Clarify that changesets should be skipped for documentation-only changes
  - Simplify the version bump guidance by deferring to `CONTRIBUTING.md` instead of duplicating criteria inline

This ensures consistent guidance across documentation and automation, reducing confusion about when changesets are needed and what version bump to use.

https://claude.ai/code/session_01ScoMxMZmjQmdvCGFt81kTB