### PR TITLE
SPIKE PROTOTYPE [INTER-2230]: Add x-gh-source extension to OpenAPI build

### DIFF
--- a/utils/transformers/resolveRefTransformer.js
+++ b/utils/transformers/resolveRefTransformer.js
@@ -4,6 +4,35 @@ import { walkJson } from '../walkJson.js';
 import path from 'path';
 
 /**
+ * Maps a schema file path (relative to the `schemas/` directory) to its
+ * source path in the private `koala` repo.
+ *
+ * Reverse of the sync config that pulls multi-file YAML from koala into
+ * this repo:
+ *   - `components/...` -> `api/v4/components/...`
+ *   - `paths/...`     -> `api/v4/paths/...`
+ *   - `fingerprint-server-api-v4.yaml` -> `api/v4/server-api.yaml`
+ *
+ * Anything else is returned as-is (after stripping a leading `./`).
+ *
+ * @param {string} refPath - path relative to the `schemas/` directory
+ * @returns {string} koala source path
+ */
+export function toKoalaPath(refPath) {
+  const p = refPath.replace(/^\.\//, '');
+
+  if (p === 'fingerprint-server-api-v4.yaml') {
+    return 'api/v4/server-api.yaml';
+  }
+
+  if (p.startsWith('components/') || p.startsWith('paths/')) {
+    return `api/v4/${p}`;
+  }
+
+  return p;
+}
+
+/**
  * Load and parse yaml file
  * @param {string} path
  * @returns {object}
@@ -13,22 +42,35 @@ function loadYaml(path) {
 }
 
 class ModelsCache {
-  constructor() {
+  /**
+   * @param {string} rootSchemaPath - absolute path to the schemas root, used to compute
+   *   the file path relative to `schemas/` for `x-gh-source` values.
+   * @param {boolean} addGhSource - when true, stamps `x-gh-source` with the koala
+   *   source file path onto each inlined schema.
+   */
+  constructor(rootSchemaPath, addGhSource = false) {
     this.models = {};
     this.refs = {};
+    this.rootSchemaPath = rootSchemaPath;
+    this.addGhSource = addGhSource;
   }
 
   /**
    * Get model by $ref
    * @param {string} modelRef
    * @param {string} schemaPath
-   * @returns {string}
+   * @returns {string|object}
    */
   get(modelRef, schemaPath = '.') {
     if (this.refs.hasOwnProperty(modelRef)) {
       return this.refs[modelRef];
     } else {
       const model = loadYaml(schemaPath + '/' + modelRef);
+      if (this.addGhSource) {
+        const fullAbs = path.resolve(schemaPath, modelRef);
+        const relativeToRoot = path.relative(this.rootSchemaPath, fullAbs);
+        model['x-gh-source'] = toKoalaPath(relativeToRoot);
+      }
       findAndResolveRefs(model, this, schemaPath + '/' + path.parse(modelRef).dir);
       const modelName = path.parse(modelRef).name;
       // Load paths inline
@@ -57,7 +99,7 @@ class ModelsCache {
  * Resolves external refs
  * For components replace ref to local and adds component to ModelsCache
  * For other external refs just inline code
- * @param {string} apiDefinition
+ * @param {object} apiDefinition
  * @param {ModelsCache} modelsCache
  * @param {string} schemaPath
  */
@@ -97,12 +139,16 @@ function findAndResolveRefs(apiDefinition, modelsCache, schemaPath) {
  * Resolves external references in an API definition and replaces them with inline code or local references.
  * @param {object} options
  * @param {string} options.schemaPath
+ * @param {boolean} [options.addGhSource] - when true, stamps `x-gh-source` with the koala
+ *   source file path onto each inlined schema.
  * @returns {(function({object}): void)}
  */
 export function resolveRefTransformer(options) {
   const schemaPath = options.schemaPath || './';
+  const addGhSource = options.addGhSource === true;
+  const rootSchemaPath = path.resolve(schemaPath);
   return function (apiDefinition) {
-    const modelsCache = new ModelsCache();
+    const modelsCache = new ModelsCache(rootSchemaPath, addGhSource);
     // resolve external refs and replace them with inline code or local ref
     findAndResolveRefs(apiDefinition, modelsCache, schemaPath);
     const models = modelsCache.serialize();

--- a/utils/transformers/resolveRefTransformerGhSource.spec.js
+++ b/utils/transformers/resolveRefTransformerGhSource.spec.js
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+import { resolveRefTransformer, toKoalaPath } from './resolveRefTransformer.js';
+import { transformSchema } from './transformSchema.js';
+
+const mocksPath = './utils/mocks';
+
+const resolveRef = (yaml, schemaPath) => transformSchema(yaml, [resolveRefTransformer({ schemaPath })]);
+const resolveRefWithGhSource = (yaml, schemaPath) =>
+  transformSchema(yaml, [resolveRefTransformer({ schemaPath, addGhSource: true })]);
+
+describe('Test resolveRefTransformer x-gh-source', () => {
+  it('does not add x-gh-source by default', () => {
+    const input = fs.readFileSync('./utils/mocks/schemaWithExternalRef.yaml');
+    const result = resolveRef(input, mocksPath);
+    expect(result).not.toContain('x-gh-source');
+  });
+
+  it('adds x-gh-source to inlined path operations and component schemas', () => {
+    const input = fs.readFileSync('./utils/mocks/schemaWithExternalRef.yaml');
+    const result = resolveRefWithGhSource(input, mocksPath);
+    expect(result).toContain('x-gh-source');
+    // path operation inlined from paths/visitors.yml
+    expect(result).toContain('x-gh-source: api/v4/paths/visitors.yml');
+    // component schemas inlined from ../components/Response.yaml and Error.yaml
+    expect(result).toContain('x-gh-source: api/v4/components/Response.yaml');
+    expect(result).toContain('x-gh-source: api/v4/components/Error.yaml');
+  });
+
+  it('strips leading ./ from ref paths before mapping', () => {
+    const yaml = `
+openapi: 3.0.3
+info:
+  title: Test API
+  version: '0.1'
+paths:
+  /visitors/{visitor_id}:
+    $ref: ./paths/visitors.yml
+`;
+    const result = resolveRefWithGhSource(yaml, mocksPath);
+    expect(result).toContain('x-gh-source: api/v4/paths/visitors.yml');
+  });
+
+  it('maps the root entrypoint file to api/v4/server-api.yaml', () => {
+    const tmpDir = fs.mkdtempSync('gh-source-test-');
+    const targetPath = path.join(tmpDir, 'fingerprint-server-api-v4.yaml');
+    fs.writeFileSync(targetPath, `type: object\ntitle: Root\nproperties:\n  ok:\n    type: boolean\n`);
+    const input = `
+openapi: 3.0.3
+info:
+  title: Test API
+  version: '0.1'
+paths: {}
+components:
+  schemas:
+    Root:
+      $ref: fingerprint-server-api-v4.yaml
+`;
+    const result = resolveRefWithGhSource(input, tmpDir);
+    expect(result).toContain('x-gh-source: api/v4/server-api.yaml');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('preserves existing schema fields when adding x-gh-source', () => {
+    const input = fs.readFileSync('./utils/mocks/schemaWithExternalRef.yaml');
+    const result = resolveRefWithGhSource(input, mocksPath);
+    // The Response schema should still have its title and properties
+    expect(result).toContain('title: Response');
+    expect(result).toContain('visitorId');
+  });
+});
+
+describe('Test toKoalaPath', () => {
+  it('maps components/ paths to api/v4/components/', () => {
+    expect(toKoalaPath('components/Response.yaml')).toBe('api/v4/components/Response.yaml');
+    expect(toKoalaPath('components/nested/Error.yml')).toBe('api/v4/components/nested/Error.yml');
+  });
+
+  it('maps paths/ paths to api/v4/paths/', () => {
+    expect(toKoalaPath('paths/visitors.yml')).toBe('api/v4/paths/visitors.yml');
+    expect(toKoalaPath('paths/events/search.yaml')).toBe('api/v4/paths/events/search.yaml');
+  });
+
+  it('maps the root entrypoint file to api/v4/server-api.yaml', () => {
+    expect(toKoalaPath('fingerprint-server-api-v4.yaml')).toBe('api/v4/server-api.yaml');
+  });
+
+  it('strips a leading ./ prefix before mapping', () => {
+    expect(toKoalaPath('./components/Response.yaml')).toBe('api/v4/components/Response.yaml');
+    expect(toKoalaPath('./paths/visitors.yml')).toBe('api/v4/paths/visitors.yml');
+    expect(toKoalaPath('./fingerprint-server-api-v4.yaml')).toBe('api/v4/server-api.yaml');
+  });
+
+  it('passes through anything else unchanged (after stripping ./)', () => {
+    expect(toKoalaPath('something/else/entirely.yaml')).toBe('something/else/entirely.yaml');
+    expect(toKoalaPath('./top-level-file.yaml')).toBe('top-level-file.yaml');
+    expect(toKoalaPath('components-not-a-prefix.yaml')).toBe('components-not-a-prefix.yaml');
+  });
+});

--- a/utils/transformers/transformSchema.js
+++ b/utils/transformers/transformSchema.js
@@ -30,11 +30,27 @@ export const commonTransformers = [
 
 const defaultTransformers = [...commonTransformers];
 
-export const v4CommonTransformers = [...commonTransformers, removeFieldsByPrefixTransformer('x-ruleset-')];
+export const v4CommonTransformers = [
+  resolveRefTransformer({ schemaPath: './schemas' }),
+  resolveExternalValueTransformer({ examplesPath: './schemas/paths/' }),
+  removeFieldTransformer('triggered_by'),
+  liftOneOfSharedPropertiesTransformer,
+  resolveAllOfTransformer,
+  removeFieldsByPrefixTransformer('x-ruleset-'),
+];
 
 export const v4Transformers = [
   ...v4CommonTransformers,
   // This transformer should run last to ensure all unused schemas are found
+  removeUnusedSchemasTransformer,
+];
+
+// Docs-only variant: same as v4Transformers but stamps `x-gh-source` on every
+// inlined schema. Used for the with-examples docs build; SDK builds must NOT
+// inherit `addGhSource`, so it lives here rather than in `v4CommonTransformers`.
+export const v4DocsTransformers = [
+  resolveRefTransformer({ schemaPath: './schemas', addGhSource: true }),
+  ...v4CommonTransformers.slice(1),
   removeUnusedSchemasTransformer,
 ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ import {
   relatedVisitorsApiTransformers,
   removeExtraDocumentationTransformers,
   schemaForSdksTransformers,
-  v4Transformers,
+  v4DocsTransformers,
   v4SchemaForSdksTransformers,
   transformSchema,
   v4SchemaForSdksNormalizedTransformers,
@@ -73,7 +73,7 @@ export default {
           // includes `oneOf` operators same as the source schema
           // includes additionalProperties: false same as the source schema
           to: 'schemas/fingerprint-server-api-v4-with-examples.yaml',
-          transform: (content) => transformSchema(content, v4Transformers),
+          transform: (content) => transformSchema(content, v4DocsTransformers),
         },
         {
           from: 'schemas/fingerprint-server-api-v4.yaml',


### PR DESCRIPTION
## ⚠️ SPIKE PROTOTYPE — NOT PRODUCTION-READY

Exploratory prototype. Do not merge.

## What

Stamps `x-gh-source` on each inlined schema during the OpenAPI build, mapping it to its source file path in `fingerprintjs/koala`. Only the docs-facing `with-examples` spec gets it; SDK specs are unaffected.

## Changes

- `resolveRefTransformer.js`: `addGhSource` option on `ModelsCache` stamps `x-gh-source` during `$ref` inlining. `toKoalaPath` helper inlined (deleted `koalaPathMapper.js`).
- `transformSchema.js`: new `v4DocsTransformers` — docs-only transformer list with `addGhSource`. Shared `v4CommonTransformers` no longer stamps.
- `webpack.config.js`: with-examples output uses `v4DocsTransformers`; SDK outputs use non-`addGhSource` lists.
- `resolveRefTransformerGhSource.spec.js`: 5 tests for `toKoalaPath` + stamping.

## Verification

- 105 tests pass
- with-examples spec: 126 `x-gh-source` stamps; SDK specs: 0

## Used by

- fingerprintjs/docs#409 — consumes `x-gh-source` for "Edit on GitHub" links