### PR TITLE
Restore `run_install` in upload workflows

### DIFF
--- a/.github/workflows/upload-changesets.yml
+++ b/.github/workflows/upload-changesets.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: true
 
       - name: Upload an Asset in GitHub Release
         uses: actions/github-script@v7

--- a/.github/workflows/upload-schemas.yml
+++ b/.github/workflows/upload-schemas.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: true
 
       - name: 'Build schemas'
         run: pnpm build


### PR DESCRIPTION
## Problem

The `Upload changesets` and `Upload schemas` workflows have been failing on release. Restoring `run_install: true` parameter to dependencies installed.