### PR TITLE
chore: make start,end parameter aliasing more robust

### DIFF
--- a/.changeset/fix-start-end-types.md
+++ b/.changeset/fix-start-end-types.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': patch
+---
+
+**events**: Fix types for `start`/`start_date_time` and `end`/`end_date_time`

--- a/.changeset/fix-start-end-types.md
+++ b/.changeset/fix-start-end-types.md
@@ -2,4 +2,4 @@
 'fingerprint-pro-server-api-openapi': patch
 ---
 
-**events**: Fix types for `start`/`start_date_time` and `end`/`end_date_time`
+**events**: Fix types for `start`/`start_date_time` and `end`/`end_date_time` in normalized schema

--- a/utils/mocks/schemaWithOneOfQueryParameter.yaml
+++ b/utils/mocks/schemaWithOneOfQueryParameter.yaml
@@ -13,7 +13,7 @@ paths:
           description: The original description
           schema:
             oneOf:
-              - type: integer
-                format: int64
               - type: string
                 format: date-time
+              - type: integer
+                format: int64

--- a/utils/transformers/expandOneOfQueryParametersTransformer.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.js
@@ -7,10 +7,11 @@ const VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME = 'x-aliased-parameter-na
  * supported.
  *
  * The replacement parameters are defined by:
- * - An override description for the first schema. This becomes the primary parameter
- * - A name and description for the second schema. This becomes the alias of the primary parameter.
+ * - The type of the primary parameter.
+ * - An override description for the primary parameter.
+ * - A name and description for alias, which uses the other schema from the `oneOf` array.
  *
- * @param {Record<string, { overrideDescription: string; alias: { name: string; description:string; } }>} replacementParametersMap
+ * @param {Record<string, { primaryType: string; overrideDescription: string; alias: { name: string; description:string; } }>} replacementParametersMap
  */
 export function expandOneOfQueryParametersTransformer(replacementParametersMap) {
   return function (apiDefinition) {
@@ -53,12 +54,20 @@ export function expandOneOfQueryParametersTransformer(replacementParametersMap) 
             throw new Error('Unsupported use of oneOf construct in query parameter');
           }
 
+          const primarySchema = oneOf.find((s) => s.type === replacementParameter.primaryType);
+          const aliasSchema = oneOf.find((s) => s !== primarySchema);
+          if (!primarySchema) {
+            throw new Error(
+              `No oneOf schema matches primaryType "${replacementParameter.primaryType}" for query parameter "${param.name}"`
+            );
+          }
+
           // The primary parameter
           expanded.push({
             ...restParam,
             schema: {
               ...restSchema,
-              ...oneOf[0],
+              ...primarySchema,
             },
             description: replacementParameter.overrideDescription,
             [VENDOR_EXTENSION_PARAMETER_ALIAS_PROPERTY_NAME]: replacementParameter.alias.name,
@@ -70,7 +79,7 @@ export function expandOneOfQueryParametersTransformer(replacementParametersMap) 
             name: replacementParameter.alias.name,
             schema: {
               ...restSchema,
-              ...oneOf[1],
+              ...aliasSchema,
             },
             description: replacementParameter.alias.description,
             [VENDOR_EXTENSION_ALIASED_PARAMETER_PROPERTY_NAME]: param.name,

--- a/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
+++ b/utils/transformers/expandOneOfQueryParametersTransformer.spec.js
@@ -10,6 +10,7 @@ const schemaWithOneOfQueryParameterTransformed = fs.readFileSync(
 
 const replacementParametersMap = {
   timestamp: {
+    primaryType: 'integer',
     overrideDescription: 'The updated description',
     alias: {
       name: 'timestamp_alias',

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -14,11 +14,11 @@ const replacementParametersMap = {
   end: {
     primaryType: 'integer',
     overrideDescription:
-      'Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.',
+      'Include events that happened before this point (with timestamp less than or equal to the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.',
     alias: {
       name: 'end_date_time',
       description:
-        'Include events that happened before this point (with timestamp less than or equal the provided `end_date_time` RFC3339 timestamp). Defaults to now. Setting `end_date_time` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed. This parameter is an alias for `end`.',
+        'Include events that happened before this point (with timestamp less than or equal to the provided `end_date_time` RFC3339 timestamp). Defaults to now. Setting `end_date_time` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed. This parameter is an alias for `end`.',
     },
   },
 };

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -8,7 +8,7 @@ const replacementParametersMap = {
     alias: {
       name: 'start_date_time',
       description:
-        'Include events that happened after this point (with timestamp greater than or equal to the provided `start_date_time` RFC3339 timestamp). Defaults to 7 days ago. Setting `start_date_time` does not the default of `now` for `end`/`end_date_time` — adjust it separately if needed. This parameter is an alias for `start`.',
+        'Include events that happened after this point (with timestamp greater than or equal to the provided `start_date_time` RFC3339 timestamp). Defaults to 7 days ago. Setting `start_date_time` does not change the default of `now` for `end`/`end_date_time` — adjust it separately if needed. This parameter is an alias for `start`.',
     },
   },
   end: {

--- a/utils/transformers/replaceStartEndQueryParameters.js
+++ b/utils/transformers/replaceStartEndQueryParameters.js
@@ -2,6 +2,7 @@ import { expandOneOfQueryParametersTransformer } from './expandOneOfQueryParamet
 
 const replacementParametersMap = {
   start: {
+    primaryType: 'integer',
     overrideDescription:
       'Include events that happened after this point (with timestamp greater than or equal to the provided `start` Unix milliseconds value). Defaults to 7 days ago. Setting `start` does not change the default of `now` for `end`/`end_date_time` — adjust it separately if needed.',
     alias: {
@@ -11,6 +12,7 @@ const replacementParametersMap = {
     },
   },
   end: {
+    primaryType: 'integer',
     overrideDescription:
       'Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value). Defaults to now. Setting `end` does not change the default of `7 days ago` for `start`/`start_date_time` — adjust it separately if needed.',
     alias: {


### PR DESCRIPTION
- Update the `expandOneOfQueryParametersTransformer` to allow the primary and alias schemas to be in any order, identifying the primary schema by type.