### PR TITLE
chore: update v3 schemas to include labels

### DIFF
--- a/.changeset/add-labels-v3.md
+++ b/.changeset/add-labels-v3.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-server-api-openapi': patch
+---
+
+**events**: Add `labels` signal to v3 schema

--- a/schemas/fingerprint-server-api-for-sdks.yaml
+++ b/schemas/fingerprint-server-api-for-sdks.yaml
@@ -6455,6 +6455,8 @@ components:
           $ref: '#/components/schemas/ProductRareDevice'
         proximity:
           $ref: '#/components/schemas/ProductProximity'
+        labels:
+          $ref: '#/components/schemas/ProductLabels'
     EventsGetResponse:
       type: object
       description: >-

--- a/schemas/fingerprint-server-api-readme-explorer.yaml
+++ b/schemas/fingerprint-server-api-readme-explorer.yaml
@@ -380,6 +380,11 @@ paths:
                           id: w1aTfd4MCvl
                           precisionRadius: 10
                           confidence: 0.95
+                      labels:
+                        data:
+                          - label: fraud
+                            prediction: false
+                            mlScore: 0.01
                 200-all-errors:
                   summary: All failed signals
                   value:
@@ -491,6 +496,10 @@ paths:
                           code: Failed
                           message: internal server error
                       proximity:
+                        error:
+                          code: Failed
+                          message: internal server error
+                      labels:
                         error:
                           code: Failed
                           message: internal server error
@@ -6821,6 +6830,33 @@ components:
           $ref: '#/components/schemas/MitMAttack'
         error:
           $ref: '#/components/schemas/Error'
+    Labels:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          label:
+            type: string
+          prediction:
+            type: boolean
+          mlScore:
+            type: number
+            format: double
+            minimum: 0
+            maximum: 1
+      description: >
+        Each label returns a prediction (true or false) for a specific use case (label field) based on a machine learning score.
+        The machine learning score is determined by a model trained on customer data for that use case. This field is in the beta phase
+        and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
+    ProductLabels:
+      type: object
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/Labels'
+        error:
+          $ref: '#/components/schemas/Error'
     Proximity:
       type: object
       description: >
@@ -6930,6 +6966,8 @@ components:
           $ref: '#/components/schemas/ProductMitMAttack'
         proximity:
           $ref: '#/components/schemas/ProductProximity'
+        labels:
+          $ref: '#/components/schemas/ProductLabels'
     EventsGetResponse:
       type: object
       description: >-


### PR DESCRIPTION
Finish adding the `labels` signal to the v3 schema. The previous PR #369 missed applying all the necessary updates for the new `labels` signal to the v3 schema.