### PR TITLE
chore: streamline creation of changesets.zip file, and document how it works

### DIFF
--- a/.github/workflows/upload-changesets.yml
+++ b/.github/workflows/upload-changesets.yml
@@ -43,8 +43,8 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
-      - name: Remove changesets zip files
-        run: rm .changeset/changesets-*.zip
+      - name: Remove changesets zip
+        run: rm .changeset/changesets.zip
 
       - name: Commit changes
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,13 +61,17 @@ To validate that schema matches the actual API implementation we use a [special 
 - If you are adding things to the schema, you can also try adding the appropriate validations for the changes to the `validateSchema.ts` script. If you run into problems, the repository maintainers will be happy to help or to add the validations themselves as part of the PR review.
 
 ### Describing changes
+
 [Releases](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/releases) from this repository are propagated to our server-side SDKs, that's why it's important to provide meaningful release notes if there are relevant changes.
 We use [changesets](https://github.com/changesets/changesets) for that. If you want to describe your changes, run:
+
 ```sh
 pnpm run changeset
-``` 
+```
+
 and follow steps in the CLI. It will create a new markdown file in `.changeset` folder, don't forget to commit it with your changes.
 Example changeset looks like this:
+
 ```markdown
 ---
 'fingerprint-pro-server-api-openapi': minor
@@ -77,6 +81,7 @@ Example changeset looks like this:
 ```
 
 #### Legend
+
 - `visitors` - scope of the changes. Scopes are defined in the [config/scopes.yaml](config/scopes.yaml) file. Certain scopes are ignored in certain SDKs if they are not supported, meaning that they will be ignored for them. You will be prompted to select scope in the CLI.
 - `Add the confidence field to the VPN Detection Smart Signal` - meaningful description of the change.
 - `fingerprint-pro-server-api-openapi` - name of the package
@@ -94,7 +99,8 @@ Don't create a changeset for documentation-only changes (descriptions, examples)
 
 ### Publishing changes
 
-On every push into `main` (merged PR):  
+On every push into `main` (merged PR):
+
 - The built schema is published to [API Reference](https://docs.fingerprint.com/reference/server-api-v4).
 - The built schema is published to [GitHub pages](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/).
 - The built schema is published as a [raw yaml file](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/schemas/fingerprint-server-api.yaml).
@@ -106,3 +112,26 @@ See the [publish.yml](.github/workflows/publish.yml) workflow for more details.
 GitHub releases are used to generate Server SDKs based on a specific version of the OpenAPI schema.
 
 After merging to `main`, if there are relevant changes, you can manually trigger the [Release](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/workflows/release.yml) workflow, which will consume created changeset files and create PR with bumped version and updated changelog.
+
+### Release note sync with SDKs
+
+There are server side SDKs (NodeJS, Go, etc) that consume the schema automatically.
+The file `.changeset/changesets.zip` is used during this process. It is **not** a build artifact, and it is not safe to delete by hand.
+
+`changeset version` deletes the markdown files once it has folded them into the changelog, but the
+SDK repositories still need the originals to generate their own changelogs when they sync to a new
+schema version. So `scripts/zipChangesets.js` archives them into `.changeset/changesets.zip` just
+before they are consumed, and that zip is committed as part of the release PR.
+
+Lifecycle:
+
+1. `pnpm changeset-version` (run by the changesets release action) zips the pending changesets, then
+   `changeset version` consumes the markdown files. The zip lands in the release PR.
+2. On release publish, `.github/workflows/upload-changesets.yml` runs
+   `scripts/uploadChangesets.cjs`, which uploads the zip as the `changesets.zip` release asset that
+   the SDK sync jobs download.
+3. The same workflow then opens a follow-up PR that removes the zip from `main`.
+
+Step 3 only runs once the upload in step 2 has succeeded, so a zip that is still on `main` holds
+changesets the SDKs never received. `zipChangesets.js` folds those into the next archive instead of
+overwriting them, so a failed release delays delivery rather than losing it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ After merging to `main`, if there are relevant changes, you can manually trigger
 
 ### Release note sync with SDKs
 
-There are server side SDKs (NodeJS, Go, etc) that consume the schema automatically.
+There are server-side SDKs (Node.js, Go, etc.) that consume the schema automatically.
 The file `.changeset/changesets.zip` is used during this process. It is **not** a build artifact, and it is not safe to delete by hand.
 
 `changeset version` deletes the markdown files once it has folded them into the changelog, but the

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-import-x": "^4.17.1",
     "express": "^5.2.1",
     "html-webpack-plugin": "^5.6.8",
-    "human-id": "^4.2.0",
     "js-yaml": "^5.2.3",
     "json-loader": "^0.5.7",
     "playwright": "^1.62.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,6 @@ importers:
       html-webpack-plugin:
         specifier: ^5.6.8
         version: 5.6.8(webpack@5.109.2)
-      human-id:
-        specifier: ^4.2.0
-        version: 4.2.0
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3

--- a/scripts/uploadChangesets.cjs
+++ b/scripts/uploadChangesets.cjs
@@ -1,37 +1,26 @@
 const fs = require('fs').promises;
-const path = require('node:path');
-const os = require('os');
-const { globSync } = require('node:fs');
-const zipLib = require('zip-lib');
-const humanId = require('human-id').humanId;
+const { existsSync } = require('node:fs');
+
+// Keep in sync with ARCHIVE_PATH in scripts/zipChangesets.js.
+const ARCHIVE_PATH = '.changeset/changesets.zip';
+
+// The SDK sync looks the release asset up by this exact name, so it must not change.
+const ASSET_NAME = 'changesets.zip';
 
 module.exports = async ({ github, context }) => {
-  // Read all zipped changesets
-  const zips = globSync('.changeset/changesets-*.zip');
-
-  // Root archive that will contain all zips contents
-  const rootArchive = new zipLib.Zip();
-
-  const tmpDir = path.join(os.tmpdir(), humanId({ capitalize: false, separator: '-' }));
-  await fs.mkdir(tmpDir);
-
-  await Promise.all(
-    zips.map(async (zip) => {
-      const archive = new zipLib.Unzip();
-
-      await archive.extract(zip, tmpDir);
-    })
-  );
-
-  await rootArchive.addFolder(tmpDir);
-  await rootArchive.archive('changesets.zip');
+  if (!existsSync(ARCHIVE_PATH)) {
+    throw new Error(
+      `${ARCHIVE_PATH} is missing, so this release would ship without changesets and the SDK syncs would fail. ` +
+        'It should have been committed to the release PR by `pnpm changeset-version`.'
+    );
+  }
 
   await github.rest.repos.uploadReleaseAsset({
-    name: 'changesets.zip',
+    name: ASSET_NAME,
     owner: context.repo.owner,
     repo: context.repo.repo,
     release_id: context.payload.release.id,
-    data: await fs.readFile('changesets.zip'),
+    data: await fs.readFile(ARCHIVE_PATH),
     headers: {
       'content-type': 'application/zip',
     },

--- a/scripts/zipChangesets.js
+++ b/scripts/zipChangesets.js
@@ -1,16 +1,48 @@
-import { globSync } from 'node:fs';
-import { humanId } from 'human-id';
+import { existsSync, globSync, mkdtempSync, readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import zip from 'zip-lib';
+
+/**
+ * Archives the changesets that are about to be consumed by `changeset version`.
+ *
+ * `changeset version` deletes the `.changeset/*.md` files once it has folded them into the
+ * changelog, but the SDK repositories still need them: they generate their own changelogs from
+ * these changesets when they sync against a new version of this schema. So we snapshot them into
+ * an archive that is committed alongside the release, attached to the GitHub release as an asset by
+ * `scripts/uploadChangesets.cjs`, and then removed from `main` by the cleanup job in
+ * `.github/workflows/upload-changesets.yml`.
+ *
+ * The cleanup job only runs after the asset upload succeeds, so an archive that is still here was
+ * never delivered to the SDKs — a release that failed to publish, for example. Its changesets are
+ * carried over into the new archive rather than overwritten, so they reach the SDKs with the next
+ * release instead of being lost.
+ */
+const ARCHIVE_PATH = '.changeset/changesets.zip';
 
 const changesets = globSync('.changeset/*.md');
 
 if (changesets.length) {
   const archive = new zip.Zip();
+  const archived = new Set();
 
   changesets.forEach((changeset) => {
-    archive.addFile(changeset);
+    const name = basename(changeset);
+
+    archive.addFile(changeset, name);
+    archived.add(name);
   });
 
-  const fileName = `.changeset/changesets-${humanId({ capitalize: false, separator: '-' })}.zip`;
-  await archive.archive(fileName);
+  if (existsSync(ARCHIVE_PATH)) {
+    const undelivered = mkdtempSync(join(tmpdir(), 'changesets-'));
+
+    await new zip.Unzip().extract(ARCHIVE_PATH, undelivered);
+
+    // On a name clash the pending changeset wins — it is the newer of the two.
+    readdirSync(undelivered)
+      .filter((name) => !archived.has(name))
+      .forEach((name) => archive.addFile(join(undelivered, name), name));
+  }
+
+  await archive.archive(ARCHIVE_PATH);
 }


### PR DESCRIPTION
Changes:
- `zipChangesets.js` writes a fixed `.changeset/changesets.zip` instead of `changesets-<humanId>.zip`, which read like a stray changeset in release PRs, see the file `.changeset/changesets-sixty-games-dress.zip` in (#454)
- When an archive is already present, its changesets are folded into the new one instead of overwritten
- `uploadChangesets.cjs` reads that one path and uploads it — no glob, no extract-to-tmpdir, no re-zip
- It now throws when the archive is missing, instead of uploading an empty asset
- Cleanup step is now `rm .changeset/changesets.zip`; the old `changesets-*.zip` pattern doesn't match the new name
- Dropped the direct `human-id` devDependency; the temp dir now comes from `fs.mkdtempSync`
- `CONTRIBUTING.md` documents what the archive is, its lifecycle, and why it's carried over

The release asset is still uploaded as `changesets.zip`, which the SDK sync looks up by [exact name](https://github.com/fingerprintjs/dx-team-toolkit/blob/main/.github/actions/update-sdk-schema/const.ts#L1).