### PR TITLE
chore: sign commits created by create-pull-request action

### DIFF
--- a/.github/workflows/upload-changesets.yml
+++ b/.github/workflows/upload-changesets.yml
@@ -46,17 +46,11 @@ jobs:
       - name: Remove changesets zip
         run: rm .changeset/changesets.zip
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
-        with:
-          add: '.'
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          message: 'chore: remove changesets zip files'
-          push: 'false'
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          commit-message: 'chore: remove changesets zip files'
           title: 'Remove changesets zip after release ${{ github.event.release.tag_name }}'
+          sign-commits: true
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           branch: chore/remove-changesets-zip-${{ github.event.release.tag_name }}


### PR DESCRIPTION
Changes:
- Drops `EndBug/add-and-commit` completely, in favor of `commit-message` functionality in `peter-evans/create-pull-request`.
- Enables signed commits