### PR TITLE
Deploy GH pages with Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,22 +5,62 @@ on:
     branches:
       - main
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  generate-schema:
-    name: Publish
+  build:
+    name: Build
     runs-on: ubuntu-latest
     environment: test
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - uses: ./.github/actions/test-and-build
         with:
           testSubscriptions: '${{ secrets.TEST_SUBSCRIPTIONS }}'
-      - name: Deploy to GitHub pages 🚀📘
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      - name: Upload GitHub pages artifact 📦
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: gh-pages
-          folder: dist
+          path: dist
+      - name: Upload built schemas for Readme 📦
+        uses: actions/upload-artifact@v7
+        with:
+          name: schemas
+          path: dist/schemas
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy-pages:
+    name: Deploy to GitHub pages 🚀📘
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+  deploy-readme:
+    name: Deploy to Readme 🚀🦉
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download built schemas
+        uses: actions/download-artifact@v8
+        with:
+          name: schemas
+          path: dist/schemas
       - name: Deploy to Readme APIv3 Reference 🚀🦉
         uses: readmeio/rdme@6c330ae4130595720421809c4eaa37ba95d07f87 # v10.9.5
         with:

--- a/.github/workflows/schema-diff-pr-comment.yml
+++ b/.github/workflows/schema-diff-pr-comment.yml
@@ -39,25 +39,12 @@ jobs:
       - name: Build schemas
         run: pnpm build
 
-      - name: Compute known remote schema files directly from gh-pages branch
+      - name: Compute known remote schema files
         id: known-remote
+        env:
+          MANIFEST_URL: https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/schemas/index.json
         run: |
-          # Pull the latest published branch metadata into FETCH_HEAD (no checkout needed).
-          git fetch --no-tags --depth=1 origin gh-pages
-
-          # Build a comma-separated list of published schema filenames:
-          # 1) list files under schemas/ in gh-pages
-          # 2) drop the schemas/ prefix
-          # 3) keep only yaml/yml files
-          # 4) join lines with commas for --known-remote-files
-          KNOWN_REMOTE_FILES="$(
-            git ls-tree -r --name-only FETCH_HEAD schemas \
-              | sed 's#^schemas/##' \
-              | grep -E '\.ya?ml$' \
-              | paste -sd, -
-          )"
-
-          # Expose the value as a step output consumed by the next step.
+          KNOWN_REMOTE_FILES="$(curl -fsSL "$MANIFEST_URL" | jq -r '.files[]' | paste -sd, -)"
           echo "files=${KNOWN_REMOTE_FILES}" >> "$GITHUB_OUTPUT"
 
       - name: Generate schema diff report

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { viteStaticCopy, type Target } from 'vite-plugin-static-copy';
 import {
   readmeApiExplorerTransformers,
@@ -69,6 +69,17 @@ const schemaOutputs = [
   },
 ];
 
+const schemaManifest = (): Plugin => ({
+  name: 'schema-manifest',
+  generateBundle() {
+    this.emitFile({
+      type: 'asset',
+      fileName: 'schemas/index.json',
+      source: `${JSON.stringify({ files: schemaOutputs.map(({ to }) => to).sort() }, null, 2)}\n`,
+    });
+  },
+});
+
 // The Swagger UI app
 export default defineConfig({
   base: './',
@@ -80,6 +91,7 @@ export default defineConfig({
     'process.env.PRIVATE_KEY': JSON.stringify(process.env.PRIVATE_KEY ?? ''),
   },
   plugins: [
+    schemaManifest(),
     viteStaticCopy({
       targets: [
         ...schemaOutputs.map(({ from, to, transformers }): Target => ({


### PR DESCRIPTION
Currently, `JamesIves/github-pages-deploy-action` can no longer push to `gh-pages` branch. Because it's not a verified commit. Artifact-based Pages deployment creates no commit, so the rule does not apply.

## Changes

- Replaces the `gh-pages` push with `actions/upload-pages-artifact` + `actions/deploy-pages`. Both of them official GitHub Actions.
- Splits `publish.yml` into `build`, `deploy-pages` and `deploy-readme` jobs. A Pages failure previously aborted the job and silently skipped Readme uploads.
- Publishes `schemas/index.json` listing the built schema files, and reads it in the schema diff workflow instead of listing the `gh-pages` branch (checkout + gh-diff).

## :warning: Before merging

Switch the Pages source to GitHub Actions. More details [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). From UI or `gh` API command:

```
gh api -X PUT repos/fingerprintjs/fingerprint-pro-server-api-openapi/pages -f build_type=workflow
```

> [!TIP]
> Safe to run beforehand. The site keeps serving the last legacy build until the first workflow deployment lands/succeeded.