### PR TITLE
Exclude Feedback API from v4 SDK schema outputs

### DIFF
--- a/utils/transformers/removeFeedbackTransformer.spec.ts
+++ b/utils/transformers/removeFeedbackTransformer.spec.ts
@@ -1,0 +1,36 @@
+import { parseYaml } from './parseYaml.ts';
+import { removeFeedbackTransformer } from './removeFeedbackTransformer.ts';
+import { transformSchema } from './transformSchema.ts';
+
+const yamlWithFeedback = `
+openapi: 3.1.1
+paths:
+  /events:
+    get: {}
+  /events/{event_id}/feedback:
+    post: {}
+`;
+
+describe('removeFeedbackTransformer', () => {
+  it('removes /events/{event_id}/feedback from paths', () => {
+    const result = transformSchema(yamlWithFeedback, [removeFeedbackTransformer]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/events/{event_id}/feedback']).toBeUndefined();
+    expect(parsed.paths['/events']).toBeDefined();
+  });
+
+  it('is a no-op when /events/{event_id}/feedback is absent', () => {
+    const yamlWithoutFeedback = `
+openapi: 3.1.1
+paths:
+  /events:
+    get: {}
+`;
+    const result = transformSchema(yamlWithoutFeedback, [removeFeedbackTransformer]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/events']).toBeDefined();
+    expect(Object.keys(parsed.paths)).toEqual(['/events']);
+  });
+});

--- a/utils/transformers/removeFeedbackTransformer.ts
+++ b/utils/transformers/removeFeedbackTransformer.ts
@@ -1,0 +1,6 @@
+import type { OpenApiDocument } from '../openapi.ts';
+
+// Removes the Feedback API endpoint from SDK schema outputs (documented in v4-with-examples only)
+export function removeFeedbackTransformer(apiDefinition: OpenApiDocument): void {
+  delete apiDefinition.paths['/events/{event_id}/feedback'];
+}

--- a/utils/transformers/transformSchema.spec.ts
+++ b/utils/transformers/transformSchema.spec.ts
@@ -123,6 +123,33 @@ describe('Test transformSchema pipelines for v4', () => {
     }
   });
 
+  it('v4 docs schema keeps /events/{event_id}/feedback when present', () => {
+    const yamlWithFeedback = toYaml({
+      openapi: '3.1.1',
+      paths: { '/events/{event_id}/feedback': { post: {} }, '/events': { get: {} } },
+      components: { schemas: {} },
+    });
+
+    const result = transformSchema(yamlWithFeedback, [...v4Transformers]);
+    const parsed = parseYaml(result);
+
+    expect(parsed.paths['/events/{event_id}/feedback']).toBeDefined();
+  });
+
+  it('v4 sdk schemas remove /events/{event_id}/feedback when present', () => {
+    const yamlWithFeedback = toYaml({
+      openapi: '3.1.1',
+      paths: { '/events/{event_id}/feedback': { post: {} }, '/events': { get: {} } },
+      components: { schemas: {} },
+    });
+
+    for (const transformers of [v4SchemaForSdksTransformers, v4SchemaForSdksNormalizedTransformers]) {
+      const result = transformSchema(yamlWithFeedback, transformers);
+      const parsed = parseYaml(result);
+      expect(parsed.paths['/events/{event_id}/feedback']).toBeUndefined();
+    }
+  });
+
   it('v4 normalized sdk schema removes response examples, additionalProperties: false, oneOf query parameters while keeping schema examples', () => {
     const result = transformSchema(v4Schema, v4SchemaForSdksNormalizedTransformers);
 

--- a/utils/transformers/transformSchema.ts
+++ b/utils/transformers/transformSchema.ts
@@ -7,6 +7,7 @@ import { extractPathOperationInlineEnumsTransformer } from './extractPathOperati
 import { parseYaml } from './parseYaml.ts';
 import { removeBigExamplesTransformer } from './removeBigExamplesTransformer.ts';
 import { removeEdgeTransformer } from './removeEdgeTransformer.ts';
+import { removeFeedbackTransformer } from './removeFeedbackTransformer.ts';
 import { removeWebhookTransformer } from './removeWebhookTransformer.ts';
 import { resolveAllOfTransformer } from './resolveAllOfTransformer.ts';
 import { resolveExternalValueTransformer } from './resolveExternalValueTransformer.ts';
@@ -46,6 +47,7 @@ export const v4SchemaForSdksCommonTransformers: Transformer[] = [
   ...v4Transformers,
   extractFirstParameterExampleTransformer,
   removeEdgeTransformer,
+  removeFeedbackTransformer,
   extractPathOperationInlineEnumsTransformer,
   replaceTagsTransformer,
   removeFieldTransformer('webhooks'),


### PR DESCRIPTION
- Add `removeFeedbackTransformer` to drop `POST /events/{event_id}/feedback` from v4 SDK schema outputs, same pattern as [`removeEdgeTransformer`](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/blob/main/utils/transformers/removeEdgeTransformer.ts)
- Wire it into `v4SchemaForSdksCommonTransformers` so Node and Go/Java/.NET SDK schemas omit the path
- Leave the path in `fingerprint-server-api-v4-with-examples.yaml` (`v4Transformers` only)

### Discussion point: source schema does not include the path yet

Koala still marks Feedback as `x-internal` ([koala#18272](https://github.com/fingerprintjs/koala/pull/18272#issuecomment-5483663888)), so this transformer is a no-op until that PR lands and syncs. After that, docs keep the endpoint and Server SDKs do not. No changeset: generated SDKs are unchanged.