### PR TITLE
ci: trigger docs OpenAPI sync after GitHub Pages deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,33 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
+  # Docs download the published GitHub Pages YAML, so this must run after deploy-pages.
+  # The docs workflows only open a PR if that file actually changed.
+  trigger-docs-sync:
+    name: Trigger docs OpenAPI sync
+    needs: deploy-pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RUNNER_APP_ID }}
+          private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
+          owner: fingerprintjs
+          repositories: docs
+      - name: Trigger docs OpenAPI spec sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # contents:write is enough for repository_dispatch; the runner app
+          # does not have actions:write, so workflow_dispatch would 403.
+          gh api --method POST repos/fingerprintjs/docs/dispatches \
+            -f event_type=openapi-schema-published
+
   deploy-readme:
     name: Deploy to Readme 🚀🦉
     needs: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ On every push into `main` (merged PR):
 - The built schema is published to [API Reference](https://docs.fingerprint.com/reference/server-api-v4).
 - The built schema is published to [GitHub pages](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/).
 - The built schema is published as a [raw yaml file](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/schemas/fingerprint-server-api.yaml).
+- After GitHub Pages deploy, the docs repo OpenAPI sync workflows run. They open a PR only if the published spec changed.
 
 See the [publish.yml](.github/workflows/publish.yml) workflow for more details.
 


### PR DESCRIPTION
- After GitHub Pages deploy, send a `repository_dispatch` (`openapi-schema-published`) to `fingerprintjs/docs`.
- Docs still opens a sync PR only if the published spec changed. Daily cron stays as a fallback.

### Discussion point: merge the docs PR first

The runner app has `contents: write`, not `actions: write`, so this uses `repository_dispatch` instead of `workflow_dispatch`. [docs#463](https://github.com/fingerprintjs/docs/pull/463) adds the matching trigger. Merge that first or the event is ignored.

### Test plan

- [ ] Merge [docs#463](https://github.com/fingerprintjs/docs/pull/463)
- [ ] Merge this, then push something to OpenAPI `main` (or re-run Publish)
- [ ] Confirm the docs sync workflows start and only open a PR if the spec changed