### PR TITLE
ci: remove leftover ReadMe OpenAPI upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish schema to GH pages and Readme
+name: Publish schema to GH pages
 
 on:
   push:
@@ -26,13 +26,6 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: dist
-      - name: Upload built schemas for Readme 📦
-        uses: actions/upload-artifact@v7
-        with:
-          name: schemas
-          path: dist/schemas
-          if-no-files-found: error
-          retention-days: 1
 
   deploy-pages:
     name: Deploy to GitHub pages 🚀📘
@@ -75,24 +68,3 @@ jobs:
           # does not have actions:write, so workflow_dispatch would 403.
           gh api --method POST repos/fingerprintjs/docs/dispatches \
             -f event_type=openapi-schema-published
-
-  deploy-readme:
-    name: Deploy to Readme 🚀🦉
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Download built schemas
-        uses: actions/download-artifact@v8
-        with:
-          name: schemas
-          path: dist/schemas
-      - name: Deploy to Readme APIv3 Reference 🚀🦉
-        uses: readmeio/rdme@6c330ae4130595720421809c4eaa37ba95d07f87 # v10.9.5
-        with:
-          rdme: openapi upload dist/schemas/fingerprint-server-api-readme-explorer.yaml --key=${{ secrets.README_API_KEY }} --slug=fingerprint-pro-server-api.json
-      - name: Deploy to Readme APIv4 Reference 🚀🦉
-        uses: readmeio/rdme@6c330ae4130595720421809c4eaa37ba95d07f87 # v10.9.5
-        with:
-          rdme: openapi upload dist/schemas/fingerprint-server-api-v4-with-examples.yaml --key=${{ secrets.README_API_KEY }} --slug=fingerprint-server-api-readme-explorer.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,10 +101,9 @@ Don't create a changeset for documentation-only changes (descriptions, examples)
 
 On every push into `main` (merged PR):
 
-- The built schema is published to [API Reference](https://docs.fingerprint.com/reference/server-api-v4).
 - The built schema is published to [GitHub pages](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/).
 - The built schema is published as a [raw yaml file](https://fingerprintjs.github.io/fingerprint-pro-server-api-openapi/schemas/fingerprint-server-api.yaml).
-- After GitHub Pages deploy, the docs repo OpenAPI sync workflows run. They open a PR only if the published spec changed.
+- After GitHub Pages deploy, the docs repo OpenAPI sync workflows run. They open a PR only if the published spec changed, which updates the [API Reference](https://docs.fingerprint.com/reference/server-api-v4).
 
 See the [publish.yml](.github/workflows/publish.yml) workflow for more details.
 


### PR DESCRIPTION
- Remove the `deploy-readme` job and the `schemas` artifact it used. Customer API reference is Mintlify, fed by the docs sync from [#468](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/pull/468).
- Point `CONTRIBUTING.md` at that docs sync instead of a direct ReadMe publish.

### Follow-up: delete `README_API_KEY`

The secret is unused after this. Safe to remove in repo settings once this merges.